### PR TITLE
Disable context-menu capturing for web target

### DIFF
--- a/src/common/components/common/preview.js
+++ b/src/common/components/common/preview.js
@@ -1,10 +1,11 @@
-import React, { useRef, useState } from 'react';
+import React, { useContext } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import cx from 'classnames';
 import Editor from './editor';
 import ExpandableEditor from './expandable-editor';
 import { IconHighlight, IconUnderline, IconNote, IconArea, IconInk, IconText } from './icons';
 import { getPopupCoordinatesFromClickEvent } from '../../lib/utilities';
+import { ReaderContext } from '../../reader';
 
 // TODO: Don't allow to select UI text in popup header and footer
 
@@ -127,6 +128,7 @@ export function PopupPreview(props) {
 
 export function SidebarPreview(props) {
 	const intl = useIntl();
+	const { platform } = useContext(ReaderContext);
 
 	function handlePageLabelClick(event) {
 		event.stopPropagation();
@@ -194,7 +196,7 @@ export function SidebarPreview(props) {
 
 	function handleContextMenu(event) {
 		let editorNode = event.target.closest('div[contenteditable="true"]');
-		if (event.button === 2 && (!editorNode || document.activeElement !== editorNode)) {
+		if (platform !== 'web' && event.button === 2 && (!editorNode || document.activeElement !== editorNode)) {
 			event.stopPropagation();
 			event.preventDefault();
 			props.onOpenContextMenu({ ids: [props.annotation.id], currentID: props.annotation.id, x: event.clientX, y: event.clientY });

--- a/src/common/components/sidebar/annotations-view.js
+++ b/src/common/components/sidebar/annotations-view.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, memo, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, memo, useCallback, useContext, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import cx from 'classnames';
@@ -6,6 +6,7 @@ import { SidebarPreview } from '../common/preview';
 import { IconColor, IconUser } from "../common/icons";
 import { ANNOTATION_COLORS } from "../../defines";
 import { pressedNextKey, pressedPreviousKey, setCaretToEnd } from '../../lib/utilities';
+import { ReaderContext } from '../../reader';
 
 function AnnotationsViewSearch({ query, onInput, onClear }) {
 	const intl = useIntl();
@@ -149,6 +150,8 @@ const AnnotationsView = memo(React.forwardRef((props, ref) => {
 	const pointerDownRef = useRef(false);
 	const selectionTimeRef = useRef(0);
 
+	const { platform } = useContext(ReaderContext);
+
 	function scrollAnnotationIntoView(id) {
 		setTimeout(() => {
 			let node = document.querySelector(`[data-sidebar-annotation-id="${id}"]`);
@@ -280,6 +283,9 @@ const AnnotationsView = memo(React.forwardRef((props, ref) => {
 	}
 
 	function handleSelectorContextMenu(event) {
+		if (platform === 'web') {
+			return;
+		}
 		event.preventDefault();
 		// if (!event.target.classList.contains('colors')
 		// 	&& !event.target.classList.contains('tags')) {

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom';
-import React from 'react';
+import React, { createContext } from 'react';
 import { IntlProvider } from 'react-intl';
 import ReaderUI from './components/reader-ui';
 import PDFView from '../pdf/pdf-view';
@@ -26,6 +26,8 @@ import { debounce } from './lib/debounce';
 // Font family is necessary for text annotations
 window.computedFontFamily = window.getComputedStyle(document.body).getPropertyValue('font-family');
 
+export const ReaderContext = createContext({});
+
 class Reader {
 	constructor(options) {
 		window.rtl = options.rtl;
@@ -35,6 +37,8 @@ class Reader {
 		this._platform = options.platform;
 		this._data = options.data;
 		this._password = options.password;
+
+		this._readerContext = { type: this._type, platform: this._platform };
 
 		this._onSaveAnnotations = options.onSaveAnnotations;
 		this._onDeleteAnnotations = options.onDeleteAnnotations;
@@ -217,55 +221,57 @@ class Reader {
 				onError={window.development && (() => {
 				})}
 			>
-				<ReaderUI
-					type={this._type}
-					state={this._state}
-					onSelectAnnotations={this.setSelectedAnnotations.bind(this)}
-					onZoomIn={this.zoomIn.bind(this)}
-					onZoomOut={this.zoomOut.bind(this)}
-					onZoomReset={this.zoomReset.bind(this)}
-					onNavigateBack={this.navigateBack.bind(this)}
-					onNavigateToPreviousPage={this.navigateToPreviousPage.bind(this)}
-					onNavigateToNextPage={this.navigateToNextPage.bind(this)}
-					onChangePageNumber={pageNumber => this.navigate({ pageNumber })}
-					onChangeTool={this.setTool.bind(this)}
-					onToggleFind={this.toggleFindPopup.bind(this)}
-					onChangeFilter={this.setFilter.bind(this)}
-					onChangeSidebarView={this.setSidebarView.bind(this)}
-					onToggleSidebar={(open) => { this.toggleSidebar(open); this._onToggleSidebar(open); }}
-					onResizeSidebar={(width) => { this.setSidebarWidth(width); this._onChangeSidebarWidth(width); }}
-					onResizeSplitView={this.setSplitViewSize.bind(this)}
-					onAddAnnotation={(annotation) => { this._annotationManager.addAnnotation(annotation); this.setSelectedAnnotations([]); } }
-					onUpdateAnnotations={(annotations) => { this._annotationManager.updateAnnotations(annotations); this._enableAnnotationDeletionFromComment = false; }}
-					onDeleteAnnotations={this._annotationManager.deleteAnnotations.bind(this._annotationManager)}
-					onOpenTagsPopup={this._onOpenTagsPopup}
-					onOpenPageLabelPopup={this._handleOpenPageLabelPopup.bind(this)}
-					onOpenColorContextMenu={params => this._onOpenContextMenu(createColorContextMenu(this, params))}
-					onOpenAnnotationContextMenu={params => this._onOpenContextMenu(createAnnotationContextMenu(this, params))}
-					onOpenSelectorContextMenu={params => this._onOpenContextMenu(createSelectorContextMenu(this, params))}
-					onOpenThumbnailContextMenu={params => this._onOpenContextMenu(createThumbnailContextMenu(this, params))}
-					onCloseContextMenu={this.closeContextMenu.bind(this)}
-					onCloseLabelOverlay={this._handleLabelOverlayClose.bind(this)}
-					onEnterPassword={this.enterPassword.bind(this)}
-					onAddToNote={this._onAddToNote}
-					onNavigate={this.navigate.bind(this)}
-					onUpdateOutline={outline => this._updateState({ outline })}
-					onRenderThumbnails={(pageIndexes) => this._primaryView._pdfThumbnails.render(pageIndexes)}
-					onSetDataTransferAnnotations={this._handleSetDataTransferAnnotations.bind(this)}
-					onOpenLink={this._onOpenLink}
+				<ReaderContext.Provider value = { this._readerContext }>
+					<ReaderUI
+						type={this._type}
+						state={this._state}
+						onSelectAnnotations={this.setSelectedAnnotations.bind(this)}
+						onZoomIn={this.zoomIn.bind(this)}
+						onZoomOut={this.zoomOut.bind(this)}
+						onZoomReset={this.zoomReset.bind(this)}
+						onNavigateBack={this.navigateBack.bind(this)}
+						onNavigateToPreviousPage={this.navigateToPreviousPage.bind(this)}
+						onNavigateToNextPage={this.navigateToNextPage.bind(this)}
+						onChangePageNumber={pageNumber => this.navigate({ pageNumber })}
+						onChangeTool={this.setTool.bind(this)}
+						onToggleFind={this.toggleFindPopup.bind(this)}
+						onChangeFilter={this.setFilter.bind(this)}
+						onChangeSidebarView={this.setSidebarView.bind(this)}
+						onToggleSidebar={(open) => { this.toggleSidebar(open); this._onToggleSidebar(open); }}
+						onResizeSidebar={(width) => { this.setSidebarWidth(width); this._onChangeSidebarWidth(width); }}
+						onResizeSplitView={this.setSplitViewSize.bind(this)}
+						onAddAnnotation={(annotation) => { this._annotationManager.addAnnotation(annotation); this.setSelectedAnnotations([]); } }
+						onUpdateAnnotations={(annotations) => { this._annotationManager.updateAnnotations(annotations); this._enableAnnotationDeletionFromComment = false; }}
+						onDeleteAnnotations={this._annotationManager.deleteAnnotations.bind(this._annotationManager)}
+						onOpenTagsPopup={this._onOpenTagsPopup}
+						onOpenPageLabelPopup={this._handleOpenPageLabelPopup.bind(this)}
+						onOpenColorContextMenu={params => this._onOpenContextMenu(createColorContextMenu(this, params))}
+						onOpenAnnotationContextMenu={params => this._onOpenContextMenu(createAnnotationContextMenu(this, params))}
+						onOpenSelectorContextMenu={params => this._onOpenContextMenu(createSelectorContextMenu(this, params))}
+						onOpenThumbnailContextMenu={params => this._onOpenContextMenu(createThumbnailContextMenu(this, params))}
+						onCloseContextMenu={this.closeContextMenu.bind(this)}
+						onCloseLabelOverlay={this._handleLabelOverlayClose.bind(this)}
+						onEnterPassword={this.enterPassword.bind(this)}
+						onAddToNote={this._onAddToNote}
+						onNavigate={this.navigate.bind(this)}
+						onUpdateOutline={outline => this._updateState({ outline })}
+						onRenderThumbnails={(pageIndexes) => this._primaryView._pdfThumbnails.render(pageIndexes)}
+						onSetDataTransferAnnotations={this._handleSetDataTransferAnnotations.bind(this)}
+						onOpenLink={this._onOpenLink}
 
-					onChangeFindState={this._handleFindStateChange.bind(this)}
-					onFindNext={this.findNext.bind(this)}
-					onFindPrevious={this.findPrevious.bind(this)}
-					onToggleFindPopup={this.toggleFindPopup.bind(this)}
+						onChangeFindState={this._handleFindStateChange.bind(this)}
+						onFindNext={this.findNext.bind(this)}
+						onFindPrevious={this.findPrevious.bind(this)}
+						onToggleFindPopup={this.toggleFindPopup.bind(this)}
 
-					onSetPortal={this._setPortal.bind(this)}
+						onSetPortal={this._setPortal.bind(this)}
 
-					onDoubleClickPageLabel={options.onDoubleClickPageLabel}
-					onFocusSplitButton={options.onFocusSplitButton}
-					onFocusContextPane={options.onFocusContextPane}
-					ref={this._readerRef}
-				/>
+						onDoubleClickPageLabel={options.onDoubleClickPageLabel}
+						onFocusSplitButton={options.onFocusSplitButton}
+						onFocusContextPane={options.onFocusContextPane}
+						ref={this._readerRef}
+					/>
+				</ReaderContext.Provider>
 			</IntlProvider>,
 			document.getElementById('reader-ui'),
 			() => {
@@ -287,11 +293,13 @@ class Reader {
 		// 	event.preventDefault();
 		// }, { passive: false });
 
-		window.addEventListener('contextmenu', (event) => {
-			if (event.target.nodeName !== 'INPUT' && !event.target.hasAttribute('contenteditable')) {
-				event.preventDefault();
-			}
-		});
+		if (this._platform !== 'web') {
+			window.addEventListener('contextmenu', (event) => {
+				if (event.target.nodeName !== 'INPUT' && !event.target.hasAttribute('contenteditable')) {
+					event.preventDefault();
+				}
+			});
+		}
 	}
 
 	_ensureType() {
@@ -724,6 +732,7 @@ class Reader {
 			primary,
 			container,
 			data,
+			platform: this._platform,
 			readOnly: this._state.readOnly,
 			tool: this._state.tool,
 			selectedAnnotationIDs: this._state.selectedAnnotationIDs,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,6 +15,8 @@ export type Tool = {
 	color?: string;
 }
 
+export type Platform = 'web' | 'zotero' | 'ios' | 'android';
+
 export type AnnotationType =
 	| 'highlight'
 	| 'underline'

--- a/src/dom/common/dom-view.tsx
+++ b/src/dom/common/dom-view.tsx
@@ -13,6 +13,7 @@ import {
 	ViewStats,
 	NavLocation,
 	MaybePromise,
+	Platform,
 } from "../../common/types";
 import PopupDelayer from "../../common/lib/popup-delayer";
 import ReactDOM from "react-dom";
@@ -657,6 +658,9 @@ abstract class DOMView<State extends DOMViewState, Data> {
 	}
 
 	private _handleContextMenu(event: MouseEvent) {
+		if (this._options.platform === 'web') {
+			return;
+		}
 		// Prevent native context menu
 		event.preventDefault();
 		if (!(event.target as Element).closest('#annotation-overlay')) {
@@ -980,6 +984,7 @@ export type DOMViewOptions<State extends DOMViewState, Data> = {
 	portal?: boolean;
 	container: Element;
 	tool: Tool;
+	platform: Platform;
 	selectedAnnotationIDs: string[];
 	annotations: WADMAnnotation[];
 	showAnnotations: boolean;

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -40,7 +40,7 @@ async function createReader() {
 		toolbarPlaceholderWidth: 0,
 		authorName: 'John',
 		showAnnotations: true,
-		platform: 'web',
+		// platform: 'web',
 		// password: 'test',
 		onOpenContextMenu(params) {
 			reader.openContextMenu(params);

--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -1378,7 +1378,7 @@ class PDFView {
 		let shift = event.shiftKey;
 		let position = this.pointerEventToPosition(event);
 
-		if (event.button === 2) {
+		if (this._options.platform !== 'web' && event.button === 2) {
 			let br = this._iframe.getBoundingClientRect();
 			let selectableAnnotation = (this.getSelectableAnnotations(position) || [])[0];
 			let selectedAnnotations = this.getSelectedAnnotations();
@@ -2088,7 +2088,9 @@ class PDFView {
 	}
 
 	_handleContextMenu(event) {
-		event.preventDefault();
+		if (this._options.platform !== 'web') {
+			event.preventDefault();
+		}
 	}
 
 	_handleKeyDown(event) {


### PR DESCRIPTION
This PR brings the following changes for the `web` target:

* Adds new `ReaderContext` to pass down `platform` (and potentially other configuration) down the tree
* Disables all context menu handlers and ensures that default behavior triggers

Also I've commented-out `platform` in `index.dev.js` so that current behavior is left unchanged during development.