### PR TITLE
Use "cursor: pointer" for buttons for web target

### DIFF
--- a/src/common/stylesheets/base/_base.scss
+++ b/src/common/stylesheets/base/_base.scss
@@ -58,8 +58,10 @@ textarea {
 	display: none !important;
 }
 
-button:hover {
-	cursor: default;
+@if $platform != "web" {
+	button:hover {
+		cursor: default;
+	}
 }
 
 

--- a/src/common/stylesheets/components/_annotations-view.scss
+++ b/src/common/stylesheets/components/_annotations-view.scss
@@ -125,7 +125,6 @@
 			}
 
 			.tag {
-				cursor: default;
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: pre;
@@ -135,6 +134,10 @@
 
 				border-radius: 6px;
 				border: 1px solid transparent;
+
+				@if $platform != 'web' {
+					cursor: default;
+				}
 
 				&.color {
 					font-weight: bold;

--- a/src/common/stylesheets/components/_findbar.scss
+++ b/src/common/stylesheets/components/_findbar.scss
@@ -88,7 +88,7 @@
 		}
 	}
 
-	@if $platform == "darwin" {
+	@if $platform == "darwin" or $platform == "web" {
 		#findPrevious {
 			padding-left: 4px;
 			padding-right: 5px;

--- a/src/common/stylesheets/components/_toolbar-buttons.scss
+++ b/src/common/stylesheets/components/_toolbar-buttons.scss
@@ -204,7 +204,7 @@
 				}
 			}
 
-			@if $platform == "darwin" {
+			@if $platform == "darwin" or $platform =="web" {
 				@include split-button(
 						$height: 24px,
 						$button: "menubutton",

--- a/src/common/stylesheets/components/_toolbar-sidebar.scss
+++ b/src/common/stylesheets/components/_toolbar-sidebar.scss
@@ -29,7 +29,7 @@
 		flex: 1 0 auto;
 		margin: $toolbar-sidebar-btn-margin;
 
-		@if $platform == "darwin" {
+		@if $platform == "darwin" or $platform =="web" {
 			@include split-button(
 					$height: $split-toolbar-btn-height,
 					$button: "sidebarbutton",

--- a/src/common/stylesheets/components/_toolbar.scss
+++ b/src/common/stylesheets/components/_toolbar.scss
@@ -99,7 +99,7 @@
 		}
 	}
 
-	@if $platform == "darwin" {
+	@if $platform == "darwin" or $platform =="web" {
 		#zoomOut,
 		#previous {
 			margin-inline-end: 1px;

--- a/src/common/stylesheets/components/_viewer-override.scss
+++ b/src/common/stylesheets/components/_viewer-override.scss
@@ -30,10 +30,14 @@ button {
 	border: none;
 	padding: 0;
 	font: inherit;
-	cursor: pointer;
 	outline: inherit;
 	display: block;
 
+	@if $platform == "web" {
+		&:not([disabled]) {
+			cursor: pointer;
+		}
+	}
 
 	&:focus-visible {
 		//border: $search-focus-border;

--- a/src/common/stylesheets/darwin.scss
+++ b/src/common/stylesheets/darwin.scss
@@ -1,4 +1,4 @@
-$platform: "darwin";
+$platform: "darwin" !default;
 $theme: "light";
 $mode: "production" !default;
 

--- a/src/common/stylesheets/web.scss
+++ b/src/common/stylesheets/web.scss
@@ -1,0 +1,4 @@
+$mode: "production";
+$platform: "web";
+
+@import "darwin";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,10 @@ function generateReaderConfig(build) {
 		mode: build === 'dev' ? 'development' : 'production',
 		devtool: build === 'zotero' ? false : 'source-map',
 		entry: {
-			reader: ['./src/index.' + build + '.js', './src/common/stylesheets/main.scss']
+			reader: [
+				'./src/index.' + build + '.js',
+				(build === 'web' ? './src/common/stylesheets/web.scss' : './src/common/stylesheets/main.scss')
+			]
 		},
 		output: {
 			path: path.resolve(__dirname, './build/' + build),


### PR DESCRIPTION
* Adds a separate top-level stylesheet `web.scss` which is picked instead of `main.scss` for web target. It overrides `$platform` global variable in scss
* Tweaks few scss rules related to buttons so that, for web target, buttons always have a different cursor on hover