### PR TITLE
Add element hiding utility for snapshots

### DIFF
--- a/src/common/components/reader-ui.js
+++ b/src/common/components/reader-ui.js
@@ -15,6 +15,7 @@ import ContextMenu from './context-menu';
 import LabelOverlay from './overlay/label-overlay';
 import PasswordOverlay from './overlay/password-overlay';
 import PrintOverlay from './overlay/print-overlay';
+import HideElementPopup from "./view/hide-element-popup";
 
 
 function View(props) {
@@ -24,6 +25,14 @@ function View(props) {
 
 	function handleFindStateChange(params) {
 		props.onChangeFindState(primary, params);
+	}
+
+	function handleHideElementClose() {
+		props.onToggleHideElementPopup({ primary, open: false });
+	}
+
+	function handleHideElementCommit(element) {
+		props.onHideElement(primary, element);
 	}
 
 	function handleFindNext() {
@@ -75,6 +84,13 @@ function View(props) {
 				<OverlayPopup
 					params={state[name + 'ViewOverlayPopup']}
 					onOpenLink={props.onOpenLink}
+				/>
+			}
+			{state[name + 'ViewHideElementPopup'] && !state.readOnly &&
+				<HideElementPopup
+					params={state[name + 'ViewHideElementPopup']}
+					onClose={handleHideElementClose}
+					onCommit={handleHideElementCommit}
 				/>
 			}
 		</div>

--- a/src/common/components/view/hide-element-popup.js
+++ b/src/common/components/view/hide-element-popup.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+function HideElementPopup(props) {
+	let { params, onClose, onCommit } = props;
+	let text;
+
+	if (params.selectedElement && params.clicked) {
+		let selectedElementTag = '<' + params.selectedElement.tagName.toLowerCase() + '>';
+		text = `Selected ${selectedElementTag} element.`;
+	}
+	else {
+		text = 'Click an element on the page to hide it.';
+	}
+
+	return (
+		<div className="hide-element-popup">
+			<div className="hide-element-status">{text}</div>
+			<div className="hide-element-buttons">
+				<button
+					className="toolbarButton"
+					onClick={() => onClose(null)}
+				>
+					Cancel
+				</button>
+				<button
+					className="toolbarButton"
+					onClick={() => onCommit(params.selectedElement)}
+					hidden={!params.selectedElement || !params.clicked}
+				>
+					Hide
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export default HideElementPopup;

--- a/src/common/context-menu.js
+++ b/src/common/context-menu.js
@@ -65,7 +65,11 @@ export function createViewContextMenu(reader, params) {
 					label: reader._getString('general.copy'),
 					disabled: !reader.canCopy,
 					onCommand: () => reader.copy()
-				}
+				},
+				reader._type === 'snapshot' && {
+					label: reader._getString('pdfReader.hideElement'),
+					onCommand: () => reader.toggleHideElementPopup({ open: true })
+				},
 			],
 			[
 				{

--- a/src/common/stylesheets/components/_hide-element-popup.scss
+++ b/src/common/stylesheets/components/_hide-element-popup.scss
@@ -1,0 +1,20 @@
+.hide-element-popup {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+
+	position: absolute;
+	right: 15px;
+	bottom: 15px;
+	width: 200px;
+	padding: 15px;
+	z-index: $z-index-findbar;
+	background-color: $findbar-bg;
+	border-radius: $findbar-border-radius;
+	box-shadow: $findbar-box-shadow;
+
+	.hide-element-buttons {
+		display: flex;
+		justify-content: flex-end;
+	}
+}

--- a/src/common/stylesheets/darwin.scss
+++ b/src/common/stylesheets/darwin.scss
@@ -62,4 +62,5 @@ $mode: "production" !default;
 @import "components/overlay";
 @import "components/outline-view";
 @import "components/thumbnails-view";
+@import "components/hide-element-popup";
 

--- a/src/dom/common/dom-view.tsx
+++ b/src/dom/common/dom-view.tsx
@@ -278,12 +278,16 @@ abstract class DOMView<State extends DOMViewState, Data> {
 		this._options.onSetOverlayPopup();
 	}
 
+	protected get _shouldRenderAnnotations() {
+		return this._showAnnotations;
+	}
+
 	protected _renderAnnotations() {
 		if (!this._iframeDocument) {
 			return;
 		}
 		let container = this._iframeDocument.body.querySelector(':scope > #annotation-overlay');
-		if (!this._showAnnotations) {
+		if (!this._shouldRenderAnnotations) {
 			if (container) {
 				container.remove();
 			}

--- a/src/dom/snapshot/stylesheets/content.css
+++ b/src/dom/snapshot/stylesheets/content.css
@@ -1,3 +1,25 @@
 ::selection {
     background-color: var(--selection-color);
 }
+
+.hide-element-current-target {
+    outline: 1px solid red !important;
+    background-color: rgb(255, 0, 0, 0.1) !important;
+}
+
+.hide-element-was-hidden {
+    /* Even if a few of these are somehow overridden, I think we'll be fine */
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 0 !important;
+    height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    z-index: -1 !important;
+    overflow: hidden !important;
+}

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -147,5 +147,6 @@ export default {
 	'pdfReader.preparingDocumentForPrinting': 'Preparing document for printing…',
 	'pdfReader.phraseNotFound': 'Phrase not found',
 	'pdfReader.selectedPages': '{count, plural, one {# page} other {# pages}} selected',
-	'pdfReader.pageOptions': 'Page Options'
+	'pdfReader.pageOptions': 'Page Options',
+	'pdfReader.hideElement': 'Hide Element'
 };

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -83,6 +83,13 @@ async function createReader() {
 		},
 		onDeletePages(pageIndexes, degrees) {
 			console.log('Deleting pages', pageIndexes, degrees);
+		},
+		onUpdateSnapshotHTML(html) {
+			console.log('Updating snapshot HTML', html);
+			return {
+				buf: new TextEncoder().encode(html),
+				url: new URL('/', window.location).toString()
+			};
 		}
 	});
 	reader.enableAddToNote(true);


### PR DESCRIPTION
Embedders will need to implement `onUpdateSnapshotHTML()`, which should update the snapshot on disk and return a promise that resolves once that's done.

(zotero/zotero#3478)