### PR TITLE
Fix unable to annotate PDFs in a browser on iOS

### DIFF
--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -516,6 +516,8 @@ class PDFView {
 		else {
 			this._iframeWindow.PDFViewerApplication.pdfCursorTools.switchTool(0);
 		}
+
+		this._iframeWindow.document.getElementById('viewerContainer').style.touchAction = tool.type !== 'pointer' ? 'none' : 'auto';
 		this._tool = tool;
 	}
 


### PR DESCRIPTION
@mrtcode OK to merge this?

While on other devices just using `preventDefault` is sufficient, on iOS this seems to be required in order to disable scrolling when a tool is selected on iOS.