### PR TITLE
Snapshot: Set zoom using privileged JS when available

### DIFF
--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -59,6 +59,7 @@ class Reader {
 		this._onIframeTab = options.onIframeTab;
 		// Only used on Zotero client, sets text/plain and text/html values from Note Markdown and Note HTML translators
 		this._onSetDataTransferAnnotations = options.onSetDataTransferAnnotations;
+		this._onSetZoom = options.onSetZoom;
 
 		this._localizedStrings = options.localizedStrings;
 
@@ -736,6 +737,10 @@ class Reader {
 			this._keyboardManager.handleViewKeyUp(event);
 		};
 
+		let onSetZoom = (iframe, zoom) => {
+			this._onSetZoom(iframe, zoom);
+		};
+
 		let data;
 		if (this._type === 'pdf') {
 			data = this._data;
@@ -811,7 +816,8 @@ class Reader {
 			});
 		} else if (this._type === 'snapshot') {
 			view = new SnapshotView({
-				...common
+				...common,
+				onSetZoom
 			});
 		}
 

--- a/src/dom/common/dom-view.tsx
+++ b/src/dom/common/dom-view.tsx
@@ -1205,6 +1205,7 @@ export type DOMViewOptions<State extends DOMViewState, Data> = {
 	onSetAnnotationPopup: (params?: AnnotationPopupParams<WADMAnnotation> | null) => void;
 	onSetOverlayPopup: (params?: OverlayPopupParams) => void;
 	onSetFindState: (state?: FindState) => void;
+	onSetZoom?: (iframe: HTMLIFrameElement, zoom: number) => void;
 	onOpenViewContextMenu: (params: { x: number, y: number }) => void;
 	onOpenAnnotationContextMenu: (params: { ids: string[], x: number, y: number, view: boolean }) => void;
 	onFocus: () => void;

--- a/src/dom/snapshot/snapshot-view.ts
+++ b/src/dom/snapshot/snapshot-view.ts
@@ -438,17 +438,23 @@ class SnapshotView extends DOMView<SnapshotViewState, SnapshotViewData> {
 
 	private _setScale(scale: number) {
 		this._scale = scale;
-		if (scale == 1) {
-			this._iframeDocument.documentElement.style.fontSize = '';
-			return;
-		}
 
-		// Calculate the default root font size, then multiply by scale.
-		// Can't just set font-size to an em value -- the page itself might set a font-size on <html>, and we need to
-		// scale relative to that.
-		this._iframeDocument.documentElement.style.fontSize = '';
-		let defaultSize = parseFloat(getComputedStyle(this._iframeDocument.documentElement).fontSize);
-		this._iframeDocument.documentElement.style.fontSize = (defaultSize * scale) + 'px';
+		if (this._options.onSetZoom) {
+			this._options.onSetZoom(this._iframe, scale);
+		}
+		else {
+			if (scale == 1) {
+				this._iframeDocument.documentElement.style.fontSize = '';
+				return;
+			}
+
+			// Calculate the default root font size, then multiply by scale.
+			// Can't just set font-size to an em value -- the page itself might set a font-size on <html>, and we need to
+			// scale relative to that.
+			this._iframeDocument.documentElement.style.fontSize = '';
+			let defaultSize = parseFloat(getComputedStyle(this._iframeDocument.documentElement).fontSize);
+			this._iframeDocument.documentElement.style.fontSize = (defaultSize * scale) + 'px';
+		}
 	}
 
 	override navigate(location: NavLocation, options: NavigateOptions = {}) {


### PR DESCRIPTION
Fixes https://forums.zotero.org/discussion/113735/zotero-7-beta-zooming-in-a-snapshot-shrinks-the-space-available-for-the-text in the client. Needs zotero/zotero#4003.