### PR TITLE
show contextmenu on touchscreen longpress

### DIFF
--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -2235,6 +2235,10 @@ class PDFView {
 	}
 
 	_handleContextMenu(event) {
+		// Open context menu on long press of touchscreen
+		if (event.mozInputSource === 5) {
+			this._handlePointerDown(event);
+		}
 		if (this._options.platform !== 'web') {
 			event.preventDefault();
 		}


### PR DESCRIPTION
When a PDF is opened in reader. Snapshots were not affected by context menu issue to begin with.

Addresses: zotero/zotero#4094