### PR TITLE
EPUB / Snapshot: Support printing

### DIFF
--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -1194,6 +1194,13 @@ class Reader {
 				window.print();
 			}
 		}
+		else {
+			// Show print popup with indeterminate progress bar
+			this._updateState({ printPopup: { percent: null } });
+			this._primaryView.print().then(() => {
+				this._updateState({ printPopup: null });
+			});
+		}
 	}
 
 	abortPrint() {

--- a/src/dom/common/dom-view.tsx
+++ b/src/dom/common/dom-view.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import annotationOverlayCSS from './stylesheets/annotation-overlay.scss';
+import injectCSS from './stylesheets/inject.scss';
 
 import {
 	Annotation,
@@ -126,7 +126,7 @@ abstract class DOMView<State extends DOMViewState, Data> {
 		});
 
 		this._iframe = document.createElement('iframe');
-		this._iframe.sandbox.add('allow-same-origin');
+		this._iframe.sandbox.add('allow-same-origin', 'allow-modals');
 		// A WebKit bug prevents listeners added by the parent page (us) from running inside a child frame (this._iframe)
 		// unless the allow-scripts permission is added to the frame's sandbox. We prevent scripts in the frame from
 		// running via the CSP.
@@ -477,7 +477,7 @@ abstract class DOMView<State extends DOMViewState, Data> {
 		this._iframeDocument.addEventListener('selectionchange', this._handleSelectionChange.bind(this));
 
 		let style = this._iframeDocument.createElement('style');
-		style.innerHTML = annotationOverlayCSS;
+		style.innerHTML = injectCSS;
 		this._iframeDocument.head.append(style);
 
 		// Pass options to setters that were delayed until iframe initialization
@@ -1172,6 +1172,8 @@ abstract class DOMView<State extends DOMViewState, Data> {
 	navigateForward() {
 		this._history.navigateForward();
 	}
+
+	abstract print(): Promise<void>;
 }
 
 export type DOMViewOptions<State extends DOMViewState, Data> = {

--- a/src/dom/common/stylesheets/inject.scss
+++ b/src/dom/common/stylesheets/inject.scss
@@ -39,3 +39,9 @@
 :root[data-color-scheme=dark]:not(.disable-dark-mode) {
 	@include -dark-rules();
 }
+
+@media print {
+	#annotation-overlay {
+		display: none !important;
+	}
+}

--- a/src/dom/epub/epub-view.ts
+++ b/src/dom/epub/epub-view.ts
@@ -1016,9 +1016,35 @@ class EPUBView extends DOMView<EPUBViewState, EPUBViewData> {
 		}
 	}
 
-	// Still need to figure out how this is going to work
-	print() {
-		console.log('Print');
+	async print() {
+		// It's going to get ugly in here, so hide the iframe
+		this._iframe.classList.remove('loaded');
+
+		// Mount all views
+		let viewsToMount = this._sectionViews.filter(view => !view.mounted);
+		for (let view of viewsToMount) {
+			view.mount();
+		}
+
+		// Wait for all images to load
+		await Promise.allSettled(
+			Array.from(this._iframeDocument.images)
+				.map(image => image.decode())
+		);
+
+		if (typeof this._iframeWindow.zoteroPrint === 'function') {
+			await this._iframeWindow.zoteroPrint();
+		}
+		else {
+			this._iframeWindow.print();
+		}
+
+		// Unmount the views that weren't mounted before
+		for (let view of viewsToMount) {
+			view.unmount();
+		}
+
+		this._iframe.classList.add('loaded');
 	}
 
 	setSidebarOpen(_sidebarOpen: boolean) {

--- a/src/dom/epub/stylesheets/_layout.scss
+++ b/src/dom/epub/stylesheets/_layout.scss
@@ -1,24 +1,32 @@
-// Can't combine the following two or it would make the specificity higher than
-// the body.flow-mode-paginated selector below.
-
-html {
-	margin: 0 !important;
-	padding: 0 !important;
-}
-
-body {
-	margin: 0 !important;
-	padding: 0 !important;
-}
-
 .swipe-indicator-left, .swipe-indicator-right {
 	display: none;
 }
 
-body.flow-mode-scrolled {
-	@import "layout/scrolled";
+@media screen {
+	// Can't combine the following two or it would make the specificity higher than
+	// the body.flow-mode-paginated selector below.
+
+	html {
+		margin: 0 !important;
+		padding: 0 !important;
+	}
+
+	body {
+		margin: 0 !important;
+		padding: 0 !important;
+	}
+
+	body.flow-mode-scrolled {
+		@import "layout/scrolled";
+	}
+
+	body.flow-mode-paginated {
+		@import "layout/paginated";
+	}
 }
 
-body.flow-mode-paginated {
-	@import "layout/paginated";
+@media print {
+	body {
+		@import "layout/print";
+	}
 }

--- a/src/dom/epub/stylesheets/layout/_print.scss
+++ b/src/dom/epub/stylesheets/layout/_print.scss
@@ -1,0 +1,3 @@
+> .sections > .section-container {
+	break-after: page;
+}

--- a/src/dom/snapshot/snapshot-view.ts
+++ b/src/dom/snapshot/snapshot-view.ts
@@ -513,9 +513,13 @@ class SnapshotView extends DOMView<SnapshotViewState, SnapshotViewData> {
 		}
 	}
 
-	// Still need to figure out how this is going to work
-	print() {
-		console.log('Print');
+	async print() {
+		if (typeof this._iframeWindow.zoteroPrint === 'function') {
+			await this._iframeWindow.zoteroPrint();
+		}
+		else {
+			this._iframeWindow.print();
+		}
 	}
 
 	setSidebarOpen(_sidebarOpen: boolean) {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -4,6 +4,8 @@ declare interface Window {
 	dev?: boolean;
 
 	DarkReader: typeof import('darkreader');
+
+	zoteroPrint?: () => Promise<void>;
 }
 
 declare interface Document {


### PR DESCRIPTION
No support for printing annotations. I can't find a way to reliably position the annotations to where they need to be on the printed page. We can force a page size and then position based on that, but pages can have their own `@media print` stylesheets which we'd need to force-apply somehow before calculating layout, and it gets messy. We can look into that later if we get requests, I guess.

Needs https://github.com/zotero/zotero/pull/4279