### PR TITLE
Fix stuck focus and missing nvda announcement

### DIFF
--- a/src/common/components/sidebar/annotations-view.js
+++ b/src/common/components/sidebar/annotations-view.js
@@ -459,7 +459,7 @@ const AnnotationsView = memo(React.forwardRef((props, ref) => {
 
 	return (
 		<React.Fragment>
-			<div id="annotations" role="listbox" className="annotations" data-tabstop={props.annotations.length ? 1 : undefined} onKeyDownCapture={handleKeyDown}>
+			<div id="annotations" role="listbox" className="annotations" data-tabstop={filteredAnnotations.length ? 1 : undefined} onKeyDownCapture={handleKeyDown}>
 				{props.annotations.length
 					? filteredAnnotations.map(annotation => (
 						<Annotation

--- a/src/common/components/sidebar/sidebar.js
+++ b/src/common/components/sidebar/sidebar.js
@@ -66,9 +66,15 @@ function Sidebar(props) {
 				</div>
 			</div>
 			<div id="sidebarContent" className="sidebar-content">
-				{props.view === 'thumbnails' && props.thumbnailsView}
-				{props.view === 'annotations' && <div id="annotationsView" role="tabpanel" aria-labelledby="viewAnnotations">{props.annotationsView}</div>}
-				{props.view === 'outline' && props.outlineView}
+				<div className={cx("viewWrapper", { hidden: props.view !== 'thumbnails'})}>
+					{props.thumbnailsView}
+				</div>
+				<div id="annotationsView" role="tabpanel" aria-labelledby="viewAnnotations" className={cx("viewWrapper", { hidden: props.view !== 'annotations'})}>
+					{props.annotationsView}
+				</div>
+				<div className={cx("viewWrapper", { hidden: props.view !== 'outline'})}>
+					{props.outlineView}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/common/components/sidebar/thumbnails-view.js
+++ b/src/common/components/sidebar/thumbnails-view.js
@@ -6,13 +6,14 @@ import { ReaderContext } from '../../reader';
 import IconOptions from '../../../../res/icons/16/options.svg';
 
 const Thumbnail = memo(({ thumbnail, selected, pageLabel, onContextMenu }) => {
+	const intl = useIntl();
 	return (
 		<div
 			className={cx('thumbnail', { selected })}
 			data-page-index={thumbnail.pageIndex}
 			onContextMenu={onContextMenu}
 			role="option"
-			aria-label={pageLabel}
+			aria-label={intl.formatMessage({ id: 'pdfReader.page' }) + `${pageLabel}`}
 			aria-selected={selected}
 			id={`thumbnail_${thumbnail.pageIndex}`}
 		>

--- a/src/common/focus-manager.js
+++ b/src/common/focus-manager.js
@@ -138,7 +138,7 @@ export class FocusManager {
 				return proxy;
 			}
 			return x;
-		});
+		}).filter(group =>!group.closest(".viewWrapper.hidden"));
 
 
 		if (reverse) {

--- a/src/common/stylesheets/components/_sidebar.scss
+++ b/src/common/stylesheets/components/_sidebar.scss
@@ -41,6 +41,10 @@ body.sidebar-open {
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
 	background-color: var(--material-sidepane);
+
+	.viewWrapper.hidden {
+		display: none;
+	}
 }
 
 #sidebarResizer {


### PR DESCRIPTION
- vpat 63: fix focus not being able to move forward on tab from "Search annotations" input in the sidebar if the search result is empty. Decide if the tabstop should be added to annotationsView based on the length of `filteredAnnotations` (which gets rendered) instead of unfiltered `props.annotations`
- vpat 73: fix NVDA not properly announcing the thumbnails view when it is selected. The "Show thumbnails" label of the view does not get announced, instead NVDA immediately announces page label of the selected thumbnail, which is a bit confusing. This happens because each time the selection changes, the view is re-added into the DOM, which tricks NVDA into thinking that there is a new component that appeared and it needs to be announced asap.
Intead, render outline, annotations and thumbnails views and just hide views that are not selected. Also, added "Page" prefix to thumbnails aria labels to give it a bit more context.
Followup to https://github.com/zotero/reader/pull/127