### PR TITLE
Reader context menu keyboard navigation

### DIFF
--- a/src/common/components/context-menu.js
+++ b/src/common/components/context-menu.js
@@ -157,12 +157,8 @@ function ContextMenu({ params, onClose }) {
 		let menuOptions = [...document.querySelectorAll(".context-menu button:not([disabled])")];
 		let candidates = menuOptions.filter(option => option.textContent.toLowerCase().startsWith(searchStringRef.current));
 		
-		// If there is only one candidate, click it right away
-		if (candidates.length == 1) {
-			candidates[0].click();
-		}
-		// If there are multiple - focus the first one
-		else if (candidates.length > 1) {
+		// Focus the first match
+		if (candidates.length) {
 			candidates[0].focus();
 		}
 	}

--- a/src/common/components/sidebar/annotations-view.js
+++ b/src/common/components/sidebar/annotations-view.js
@@ -175,7 +175,11 @@ const AnnotationsView = memo(React.forwardRef((props, ref) => {
 		props.onUpdateAnnotations([annotation]);
 	}, []);
 
-	function handlePointerDown() {
+	function handlePointerDown(event) {
+		// Clicking on the rendered content when a contextmenu is open will
+		// lead to pointerup event not firing and the annotation becoming not-selectable
+		// via keyboard until it is clicked.
+		if (event.target.classList.contains("context-menu-overlay")) return;
 		pointerDownRef.current = true;
 	}
 

--- a/src/common/components/sidebar/annotations-view.js
+++ b/src/common/components/sidebar/annotations-view.js
@@ -176,10 +176,6 @@ const AnnotationsView = memo(React.forwardRef((props, ref) => {
 	}, []);
 
 	function handlePointerDown(event) {
-		// Clicking on the rendered content when a contextmenu is open will
-		// lead to pointerup event not firing and the annotation becoming not-selectable
-		// via keyboard until it is clicked.
-		if (event.target.classList.contains("context-menu-overlay")) return;
 		pointerDownRef.current = true;
 	}
 

--- a/src/common/focus-manager.js
+++ b/src/common/focus-manager.js
@@ -135,6 +135,18 @@ export class FocusManager {
 			e.preventDefault();
 			this.tabToItem(true);
 		}
+		// If context menu is opened and a character is typed, forward the event to context menu
+		// so it can select a menuitem, similar to how native menus do it.
+		let contextMenu = document.querySelector('.context-menu');
+		if (contextMenu && e.key.length == 1 && !e.forwardedToContextMenu && !contextMenu.contains(e.target)) {
+			let eventCopy = new KeyboardEvent('keydown', {
+				key: e.key,
+				bubbles: true
+			});
+			// Mark the event to skip it when it gets captured here to avoid infinite loop
+			eventCopy.forwardedToContextMenu = true;
+			contextMenu.dispatchEvent(eventCopy);
+		}
 	}
 
 	tabToGroup(reverse) {


### PR DESCRIPTION
- add tabstop to contextMenu, so navigation between buttons within it is handled by focusManager
- when context menu is opened, focus the first button from contextMenu so that the next keypress interacts with menu items
- when Escape keypress is being handled and contextmenu is open, just call reader.closeContextMenu to close it and let focus go back to previously focused element.
- add keydown listener to context-menu to navigate it by typing characters on the keyboard. After something is typed, find buttons with text that begins with the input. If there is only one match, it is clicked. If there are multiple, the first one is focused. The input counter is reset after 3 seconds of not typing.

Fixes: https://github.com/zotero/zotero/issues/4681


Also, fixed an [encountered glitch](https://github.com/zotero/zotero/issues/4681#issuecomment-2349860842) where clicking inside of the rendered reader content when the context menu is open would make the annotation un-selectable via tab.


Currently, getting into the menu or navigating it with keyboard is not possible. For comparison, this is the updated behavior. In the end, i type "gre" to get the "Green" option selected.


https://github.com/user-attachments/assets/4cb607f8-418b-4a43-994f-ae83b6e0816f

