### PR TITLE
PDF: Performance improvement

### DIFF
--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -1950,11 +1950,13 @@ class PDFView {
 						this._onSetOverlayPopup(null);
 					});
 				}
+				if (clickableOverlay || overlayWithPopup) {
+					this._render();
+				}
 			}
 			else {
 				this.updateCursor();
 			}
-			this._render();
 			return;
 		}
 

--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -603,7 +603,32 @@ class PDFView {
 
 
 	_render(pageIndexes) {
+		let viewer = this._iframeWindow.PDFViewerApplication.pdfViewer;
+		let container = viewer.container;
+		let pages = viewer._pages;
+
+		const top = container.scrollTop,
+		  bottom = top + container.clientHeight;
+		const left = container.scrollLeft,
+		  right = left + container.clientWidth;
+
 		for (let page of this._pages) {
+			let element = pages[page.pageIndex].div;
+			const currentWidth = element.offsetLeft + element.clientLeft;
+			const currentHeight = element.offsetTop + element.clientTop;
+			const viewWidth = element.clientWidth,
+			  viewHeight = element.clientHeight;
+			const viewRight = currentWidth + viewWidth;
+			const viewBottom = currentHeight + viewHeight;
+			if (
+			  viewBottom <= top ||
+			  currentHeight >= bottom ||
+			  viewRight <= left ||
+			  currentWidth >= right
+			) {
+			  continue;
+			}
+
 			if (!pageIndexes || pageIndexes.includes(page.pageIndex)) {
 				page.render();
 			}


### PR DESCRIPTION
Function `_render()` in PDFView is a time-consuming operation and it's a bit overused .This PR tries to eliminate unnecessary invocatins of the function, which would improve the performance significantly. With this PR, Zotero is much more responsive from my test.