### PR TITLE
vpat 81: instructions for keyboard interface

### DIFF
--- a/src/common/components/reader-ui.js
+++ b/src/common/components/reader-ui.js
@@ -80,6 +80,7 @@ function View(props) {
 					onFindNext={handleFindNext}
 					onFindPrevious={handleFindPrevious}
 					onAddAnnotation={props.onAddAnnotation}
+					tools={props.tools}
 				/>
 			}
 		</div>

--- a/src/common/components/toolbar.js
+++ b/src/common/components/toolbar.js
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import cx from 'classnames';
 import CustomSections from './common/custom-sections';
 import { ReaderContext } from '../reader';
-
+import { isMac } from '../lib/utilities';
 import { IconColor20 } from './common/icons';
 
 import IconSidebar from '../../../res/icons/20/sidebar.svg';
@@ -70,6 +70,15 @@ function Toolbar(props) {
 		if (event.target.value != (props.pageLabel ?? (props.pageIndex + 1))) {
 			props.onChangePageNumber(event.target.value);
 		}
+	}
+
+	// Add aria instructions on how to add annotations with keyboard
+	function _constructAriaDecription(number) {
+		// Cmd/Alt+Option+1/2
+		let underlineOrHighlight = number <= 2;
+		let instruction = intl.formatMessage({ id: `pdfReader.a11y${underlineOrHighlight ? 'Textual' : ''}AnnotationInstruction` });
+		let modifier = intl.formatMessage({ id: `pdfReader.a11yAnnotationModifier${isMac() ? 'Mac' : ''}` });
+		return `${instruction} ${modifier} - ${number}`;
 	}
 
 	return (
@@ -177,6 +186,7 @@ function Toolbar(props) {
 					title={intl.formatMessage({ id: 'pdfReader.highlightText' })}
 					disabled={props.readOnly}
 					onClick={() => handleToolClick('highlight')}
+					aria-description={_constructAriaDecription(1)}
 				><IconHighlight/></button>
 				{ (platform !== 'web' || ['epub', 'snapshot'].includes(props.type)) && (
 					<button
@@ -185,6 +195,7 @@ function Toolbar(props) {
 						title={intl.formatMessage({ id: 'pdfReader.underlineText' })}
 						disabled={props.readOnly}
 						onClick={() => handleToolClick('underline')}
+						aria-description={_constructAriaDecription(2)}
 					><IconUnderline/></button>
 				)}
 				<button
@@ -195,6 +206,7 @@ function Toolbar(props) {
 					title={intl.formatMessage({ id: 'pdfReader.addNote' })}
 					disabled={props.readOnly}
 					onClick={() => handleToolClick('note')}
+					aria-description={_constructAriaDecription(3)}
 				><IconNote/></button>
 				{props.type === 'pdf' && platform !== 'web' && (
 					<button
@@ -203,6 +215,7 @@ function Toolbar(props) {
 						title={intl.formatMessage({ id: 'pdfReader.addText' })}
 						disabled={props.readOnly}
 						onClick={() => handleToolClick('text')}
+						aria-description={_constructAriaDecription(4)}
 					><IconText/></button>
 				)}
 				{props.type === 'pdf' && (
@@ -212,6 +225,7 @@ function Toolbar(props) {
 						title={intl.formatMessage({ id: 'pdfReader.selectArea' })}
 						disabled={props.readOnly}
 						onClick={() => handleToolClick('image')}
+						aria-description={_constructAriaDecription(5)}
 					><IconImage/></button>
 				)}
 				{props.type === 'pdf' && (
@@ -221,6 +235,7 @@ function Toolbar(props) {
 						title={intl.formatMessage({ id: 'pdfReader.draw' })}
 						disabled={props.readOnly}
 						onClick={() => handleToolClick('ink')}
+						aria-description={intl.formatMessage({ id: 'pdfReader.a11yAnnotationNotSupported' })}
 					><IconInk/></button>
 				)}
 				<div className="divider"/>

--- a/src/common/components/view-popup/find-popup.js
+++ b/src/common/components/view-popup/find-popup.js
@@ -9,7 +9,7 @@ import IconChevronDown from '../../../../res/icons/20/chevron-down.svg';
 import IconClose from '../../../../res/icons/20/x.svg';
 import { getCodeCombination, getKeyCombination } from '../../lib/utilities';
 
-function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotation }) {
+function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotation, tools }) {
 	const intl = useIntl();
 	const inputRef = useRef();
 	const preventInputRef = useRef(false);
@@ -72,13 +72,13 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 		else if (code === 'Ctrl-Alt-Digit1') {
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
-				onAddAnnotation({ ...params.result.annotation, type: 'highlight' }, true);
+				onAddAnnotation({ ...params.result.annotation, type: 'highlight', color: tools['highlight'].color }, true);
 			}
 		}
 		else if (code === 'Ctrl-Alt-Digit2') {
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
-				onAddAnnotation({ ...params.result.annotation, type: 'underline' }, true);
+				onAddAnnotation({ ...params.result.annotation, type: 'underline', color: tools['underline'].color }, true);
 			}
 		}
 	}

--- a/src/common/components/view-popup/find-popup.js
+++ b/src/common/components/view-popup/find-popup.js
@@ -7,7 +7,7 @@ import { DEBOUNCE_FIND_POPUP_INPUT } from '../../defines';
 import IconChevronUp from '../../../../res/icons/20/chevron-up.svg';
 import IconChevronDown from '../../../../res/icons/20/chevron-down.svg';
 import IconClose from '../../../../res/icons/20/x.svg';
-import { getCodeCombination, getKeyCombination } from '../../lib/utilities';
+import { getCodeCombination, getKeyCombination, isMac } from '../../lib/utilities';
 
 function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotation, tools }) {
 	const intl = useIntl();
@@ -73,12 +73,16 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
 				onAddAnnotation({ ...params.result.annotation, type: 'highlight', color: tools['highlight'].color }, true);
+				// Close popup after adding annotation
+				onChange({ ...params, popupOpen: false, active: false, result: null });
 			}
 		}
 		else if (code === 'Ctrl-Alt-Digit2') {
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
 				onAddAnnotation({ ...params.result.annotation, type: 'underline', color: tools['underline'].color }, true);
+				// Close popup after adding annotation
+				onChange({ ...params, popupOpen: false, active: false, result: null });
 			}
 		}
 	}
@@ -109,6 +113,11 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 						title={intl.formatMessage({ id: 'pdfReader.find' })}
 						className="toolbar-text-input"
 						placeholder="Find in document…"
+						aria-description={
+							intl.formatMessage({ id: 'pdfReader.a11yTextualAnnotationFindInDocumentInstruction' })
+							+ ` ${intl.formatMessage({ id: 'pdfReader.a11yAnnotationModifierControl' })} - ${intl.formatMessage({ id: `pdfReader.a11yAnnotationModifier${isMac() ? 'Mac' : ''}` })} - ${1}`
+							+ `, ${intl.formatMessage({ id: 'pdfReader.a11yAnnotationModifierControl' })} - ${intl.formatMessage({ id: `pdfReader.a11yAnnotationModifier${isMac() ? 'Mac' : ''}` })} - ${2}`
+						}
 						value={query !== null ? query : params.query}
 						tabIndex="-1"
 						data-tabstop={1}

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -877,7 +877,7 @@ class Reader {
 		let onFocusAnnotation = (annotation) => {
 			if (!annotation) return;
 			// Announce the current annotation to screen readers
-			if (annotation.type == "external-link") {
+			if (annotation.type == 'external-link') {
 				this.setA11yMessage(annotation.url);
 				return;
 			}

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -273,8 +273,7 @@ class Reader {
 								annotation = this._annotationManager.addAnnotation(annotation);
 								// Tell screen readers the annotation was added after focus is settled
 								setTimeout(() => {
-									let annotationType = this._getString(`pdfReader.${annotation.type}Annotation`);
-									this.setA11yMessage(annotationType + ' ' + this._getString('pdfReader.a11yAnnotationCreated'));
+									this.setA11yMessage(this._getString(`pdfReader.a11yAnnotationCreated.${annotation.type}`));
 								}, 100);
 								if (select) {
 									this.setSelectedAnnotations([annotation.id]);
@@ -789,8 +788,7 @@ class Reader {
 			annotation = this._annotationManager.addAnnotation(annotation);
 			// Tell screen readers the annotation was added after focus is settled
 			setTimeout(() => {
-				let annotationType = this._getString(`pdfReader.${annotation.type}Annotation`);
-				this.setA11yMessage(annotationType + ' ' + this._getString('pdfReader.a11yAnnotationCreated'));
+				this.setA11yMessage(this._getString(`pdfReader.a11yAnnotationCreated.${annotation.type}`));
 			}, 100);
 			if (select) {
 				this.setSelectedAnnotations([annotation.id], true);
@@ -1218,8 +1216,7 @@ class Reader {
 					// After a small delay for focus to settle, announce to screen readers that annotation
 					// is selected and how one can manipulate it
 					setTimeout(() => {
-						let annotationType = this._getString(`pdfReader.${annotation.type}Annotation`);
-						let a11yAnnouncement = annotationType + ' ' + this._getString('pdfReader.a11yAnnotationSelected');
+						let a11yAnnouncement = this._getString(`pdfReader.a11yAnnotationSelected.${annotation.type}`);
 						if (document.querySelector('.annotation-popup')) {
 							// add note that popup is opened
 							a11yAnnouncement += ' ' + this._getString('pdfReader.a11yAnnotationPopupAppeared');

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -307,6 +307,7 @@ class Reader {
 							onToggleContextPane={this._onToggleContextPane}
 							onChangeTextSelectionAnnotationMode={this.setTextSelectionAnnotationMode.bind(this)}
 							ref={this._readerRef}
+							tools={this._tools}
 						/>
 					</ReaderContext.Provider>
 				</IntlProvider>

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -195,13 +195,13 @@ export default {
     'pdfReader.a11yAnnotationModifier': 'Alt',
     'pdfReader.a11yAnnotationModifierControl': 'Control',
     'pdfReader.a11yTextualAnnotationFindInDocumentInstruction': 'To turn a search result into a highlight or underline annotation, press',
-    'pdfReader.a11yTextualAnnotationInstruction': 'To annotate text via keyboard, use \'Find in document\' to locate the phrase. Then, to turn search result into an annotation, press Control -',
-    'pdfReader.a11yAnnotationInstruction': 'To add this annotation into the document, focus the document and press Control -',
-    'pdfReader.a11yAnnotationNotSupported': 'Keyboard interface for this annotation type is not supported',
-    'pdfReader.a11yMoveAnnotation': 'Use arrow keys to move the annotation.',
-    'pdfReader.a11yEditTextAnnotation': 'To move the end of the text annotation, use arrow keys while holding Shift. To move the start of the annotation, use arrows while holding Shift -',
-    'pdfReader.a11yResizeAnnotation': 'Use arrow keys while holding Shift to resize the annotation.',
-    'pdfReader.a11yAnnotationSelected': 'selected',
-    'pdfReader.a11yAnnotationPopupAppeared': 'Use tab to navigate annotation details popup.',
-	'pdfReader.a11yAnnotationCreated': "has been created"
+    'pdfReader.a11yTextualAnnotationInstruction': 'To annotate text via the keyboard, first use “Find in Document” to locate the phrase. Then, to turn the search result into an annotation, press Control -',
+    'pdfReader.a11yAnnotationInstruction': 'To add this annotation to the document, focus the document and press Control -',
+    'pdfReader.a11yAnnotationNotSupported': 'This annotation type cannot be created via the keyboard.',
+    'pdfReader.a11yMoveAnnotation': 'Use the arrow keys to move the annotation.',
+    'pdfReader.a11yEditTextAnnotation': 'To move the end of the text annotation, use the left/right arrow keys while holding Shift. To move the start of the annotation, use the arrow keys while holding Shift -',
+    'pdfReader.a11yResizeAnnotation': 'To resize the annotation, use the arrow keys while holding Shift.',
+    'pdfReader.a11yAnnotationSelected': 'Annotation selected',
+    'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.'
+
 };

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -190,5 +190,18 @@ export default {
 	'pdfReader.convertToHighlight': 'Convert to Highlight',
 	'pdfReader.convertToUnderline': 'Convert to Underline',
 	'pdfReader.size': 'Size',
-	'pdfReader.merge': 'Merge'
+	'pdfReader.merge': 'Merge',
+    'pdfReader.a11yAnnotationModifierMac': 'Option',
+    'pdfReader.a11yAnnotationModifier': 'Alt',
+    'pdfReader.a11yAnnotationModifierControl': 'Control',
+    'pdfReader.a11yTextualAnnotationFindInDocumentInstruction': 'To turn a search result into a highlight or underline annotation, press',
+    'pdfReader.a11yTextualAnnotationInstruction': 'To annotate text via keyboard, use \'Find in document\' to locate the phrase. Then, to turn search result into an annotation, press Control -',
+    'pdfReader.a11yAnnotationInstruction': 'To add this annotation into the document, focus the document and press Control -',
+    'pdfReader.a11yAnnotationNotSupported': 'Keyboard interface for this annotation type is not supported',
+    'pdfReader.a11yMoveAnnotation': 'Use arrow keys to move the annotation.',
+    'pdfReader.a11yEditTextAnnotation': 'To move the end of the text annotation, use arrow keys while holding Shift. To move the start of the annotation, use arrows while holding Shift -',
+    'pdfReader.a11yResizeAnnotation': 'Use arrow keys while holding Shift to resize the annotation.',
+    'pdfReader.a11yAnnotationSelected': 'selected',
+    'pdfReader.a11yAnnotationPopupAppeared': 'Use tab to navigate annotation details popup.',
+	'pdfReader.a11yAnnotationCreated': "has been created"
 };

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -201,8 +201,17 @@ export default {
     'pdfReader.a11yMoveAnnotation': 'Use the arrow keys to move the annotation.',
     'pdfReader.a11yEditTextAnnotation': 'To move the end of the text annotation, use the left/right arrow keys while holding Shift. To move the start of the annotation, use the arrow keys while holding Shift -',
     'pdfReader.a11yResizeAnnotation': 'To resize the annotation, use the arrow keys while holding Shift.',
-    'pdfReader.a11yAnnotationSelected': 'selected.',
     'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.',
-	'pdfReader.a11yAnnotationCreated': 'has been created.',
 
+    "pdfReader.a11yAnnotationCreated.highlight": "A highlight annotation has been created.",
+    "pdfReader.a11yAnnotationCreated.underline": "An underline annotation has been created.",
+    "pdfReader.a11yAnnotationCreated.note": "A note annotation has been created.",
+    "pdfReader.a11yAnnotationCreated.text": "A text annotation has been created.",
+    "pdfReader.a11yAnnotationCreated.image": "An image annotation has been created.",
+
+    "pdfReader.a11yAnnotationSelected.highlight": "A highlight annotation has been selected.",
+    "pdfReader.a11yAnnotationSelected.underline": "An underline annotation has been selected.",
+    "pdfReader.a11yAnnotationSelected.note": "A note annotation has been selected.",
+    "pdfReader.a11yAnnotationSelected.text": "A text annotation has been selected.",
+    "pdfReader.a11yAnnotationSelected.image": "An image annotation has been selected."
 };

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -201,7 +201,8 @@ export default {
     'pdfReader.a11yMoveAnnotation': 'Use the arrow keys to move the annotation.',
     'pdfReader.a11yEditTextAnnotation': 'To move the end of the text annotation, use the left/right arrow keys while holding Shift. To move the start of the annotation, use the arrow keys while holding Shift -',
     'pdfReader.a11yResizeAnnotation': 'To resize the annotation, use the arrow keys while holding Shift.',
-    'pdfReader.a11yAnnotationSelected': 'Annotation selected',
-    'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.'
+    'pdfReader.a11yAnnotationSelected': 'selected.',
+    'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.',
+	'pdfReader.a11yAnnotationCreated': 'has been created.',
 
 };

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -203,15 +203,15 @@ export default {
     'pdfReader.a11yResizeAnnotation': 'To resize the annotation, use the arrow keys while holding Shift.',
     'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.',
 
-    "pdfReader.a11yAnnotationCreated.highlight": "A highlight annotation has been created.",
-    "pdfReader.a11yAnnotationCreated.underline": "An underline annotation has been created.",
-    "pdfReader.a11yAnnotationCreated.note": "A note annotation has been created.",
-    "pdfReader.a11yAnnotationCreated.text": "A text annotation has been created.",
-    "pdfReader.a11yAnnotationCreated.image": "An image annotation has been created.",
+    "pdfReader.a11yAnnotationCreated.highlight": "Highlight annotation created.",
+    "pdfReader.a11yAnnotationCreated.underline": "Underline annotation created.",
+    "pdfReader.a11yAnnotationCreated.note": "Note annotation created.",
+    "pdfReader.a11yAnnotationCreated.text": "Text annotation created.",
+    "pdfReader.a11yAnnotationCreated.image": "Image annotation created.",
 
-    "pdfReader.a11yAnnotationSelected.highlight": "A highlight annotation has been selected.",
-    "pdfReader.a11yAnnotationSelected.underline": "An underline annotation has been selected.",
-    "pdfReader.a11yAnnotationSelected.note": "A note annotation has been selected.",
-    "pdfReader.a11yAnnotationSelected.text": "A text annotation has been selected.",
-    "pdfReader.a11yAnnotationSelected.image": "An image annotation has been selected."
+    "pdfReader.a11yAnnotationSelected.highlight": "Highlight annotation selected.",
+    "pdfReader.a11yAnnotationSelected.underline": "Underline annotation selected.",
+    "pdfReader.a11yAnnotationSelected.note": "Note annotation selected.",
+    "pdfReader.a11yAnnotationSelected.text": "Text annotation selected.",
+    "pdfReader.a11yAnnotationSelected.image": "Image annotation selected."
 };

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -203,15 +203,15 @@ export default {
     'pdfReader.a11yResizeAnnotation': 'To resize the annotation, use the arrow keys while holding Shift.',
     'pdfReader.a11yAnnotationPopupAppeared': 'Use Tab to navigate the annotation popup.',
 
-    "pdfReader.a11yAnnotationCreated.highlight": "Highlight annotation created.",
-    "pdfReader.a11yAnnotationCreated.underline": "Underline annotation created.",
-    "pdfReader.a11yAnnotationCreated.note": "Note annotation created.",
-    "pdfReader.a11yAnnotationCreated.text": "Text annotation created.",
-    "pdfReader.a11yAnnotationCreated.image": "Image annotation created.",
+    "pdfReader.a11yAnnotationCreated.highlight": "Highlight annotation created",
+    "pdfReader.a11yAnnotationCreated.underline": "Underline annotation created",
+    "pdfReader.a11yAnnotationCreated.note": "Note annotation created",
+    "pdfReader.a11yAnnotationCreated.text": "Text annotation created",
+    "pdfReader.a11yAnnotationCreated.image": "Image annotation created",
 
-    "pdfReader.a11yAnnotationSelected.highlight": "Highlight annotation selected.",
-    "pdfReader.a11yAnnotationSelected.underline": "Underline annotation selected.",
-    "pdfReader.a11yAnnotationSelected.note": "Note annotation selected.",
-    "pdfReader.a11yAnnotationSelected.text": "Text annotation selected.",
-    "pdfReader.a11yAnnotationSelected.image": "Image annotation selected."
+    "pdfReader.a11yAnnotationSelected.highlight": "Highlight annotation selected",
+    "pdfReader.a11yAnnotationSelected.underline": "Underline annotation selected",
+    "pdfReader.a11yAnnotationSelected.note": "Note annotation selected",
+    "pdfReader.a11yAnnotationSelected.text": "Text annotation selected",
+    "pdfReader.a11yAnnotationSelected.image": "Image annotation selected"
 };


### PR DESCRIPTION
- added aria-descritions for buttons in the toolbar that tell what shortcuts exist and how to use them for different annotation types
- added aria-description to the input in 'Find in document' popup to tell that one can create annotations from search results
- when annotation is selected, announce a message saying that the annotation is selected, indicating that a popup appeared (if no sidebar), and telling how one can manipulate the annotation (more/resize/etc.)

A few minor functional tweaks:
- when annotation is added from "Find in document", close the popup and focus the view. Otherwise, one is likely to close popup with Escape and then they would have to tab to the annotation again.
- when a note is added via keyboard shortcut, do focus the comment, since the instruction has to be "Use ctrl-option-3 to add a note annotation", and
if comment is not focused, one would create an empty note and then have to tab all the way to the sidebar and find it before being able to edit it.

I'll be doing some more testing with different screen readers but @mrtcode I wanted to check with you if this approach makes sense