### PR TITLE
use simpler reader.ftl, construct announcements on the fly

### DIFF
--- a/index.reader.html
+++ b/index.reader.html
@@ -9,8 +9,8 @@
 	<script src="resource://zotero/react-dom.js"></script>
 	<script src="resource://zotero/react-intl.js"></script>
 	<script src="resource://zotero/prop-types.js"></script>
-	<link rel="localization" href="reader.ftl"/>
 	<link rel="localization" href="zotero.ftl"/>
+	<link rel="localization" href="reader.ftl"/>
 	<% } %>
 </head>
 <body class="sidebar-open">

--- a/index.reader.html
+++ b/index.reader.html
@@ -10,6 +10,7 @@
 	<script src="resource://zotero/react-intl.js"></script>
 	<script src="resource://zotero/prop-types.js"></script>
 	<link rel="localization" href="reader.ftl"/>
+	<link rel="localization" href="zotero.ftl"/>
 	<% } %>
 </head>
 <body class="sidebar-open">

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -275,7 +275,8 @@ class Reader {
 								setTimeout(async () => {
 									// Temporary until web library supports fluent
 									if (!document.l10n) return;
-									let msg = await document.l10n.formatValue('pdfReader-a11yAnnotationCreated', { type : annotation.type } );
+									let annotationType = await document.l10n.formatValue(`pdfReader-${annotation.type}Annotation`);
+									let msg = await document.l10n.formatValue('pdfReader-a11yAnnotationCreated', { type : annotationType } );
 									this.setA11yMessage(msg);
 								}, 100);
 								if (select) {
@@ -793,7 +794,8 @@ class Reader {
 			setTimeout(async () => {
 				// Temporary until web library supports fluent
 				if (!document.l10n) return;
-				let msg = await document.l10n.formatValue('pdfReader-a11yAnnotationCreated', { type : annotation.type } );
+				let annotationType = await document.l10n.formatValue(`pdfReader-${annotation.type}Annotation`);
+				let msg = await document.l10n.formatValue('pdfReader-a11yAnnotationCreated', { type : annotationType } );
 				this.setA11yMessage(msg);
 			}, 100);
 			if (select) {
@@ -1224,8 +1226,22 @@ class Reader {
 					setTimeout(async () => {
 						// Temporary until web library supports fluent
 						if (!document.l10n) return;
-						let popupVisible = document.querySelector('.annotation-popup') ? "yes" : "no";
-						let a11yAnnouncement = await document.l10n.formatValue('pdfReader-a11yAnnotationSelected', { type: annotation.type, popupVisible });
+						let annotationType =  await document.l10n.formatValue(`pdfReader-${annotation.type}Annotation`);
+						let a11yAnnouncement = await document.l10n.formatValue('pdfReader-a11yAnnotationSelected', { type: annotationType });
+						// Announce if there is a popup.
+						if (document.querySelector('.annotation-popup')) {
+							a11yAnnouncement += ' ' + await document.l10n.formatValue('pdfReader-a11yAnnotationPopupAppeared');
+						}
+						// Announce available keyboard interface options for this annotation type
+						if (['highlight', 'underline'].includes(annotation.type)) {
+							a11yAnnouncement += ' ' + await document.l10n.formatValue('pdfReader-a11yEditTextAnnotation');
+						}
+						else if (['note', 'text', 'image'].includes(annotation.type)) {
+							a11yAnnouncement += ' ' + await document.l10n.formatValue('pdfReader-a11yMoveAnnotation');
+							if (['text', 'image'].includes(annotation.type)) {
+								a11yAnnouncement += ' ' + await document.l10n.formatValue('pdfReader-a11yResizeAnnotation');
+							}
+						}
 						// only announce if the content view is focused. E.g. if comment in
 						// sidebar has focus, say nothing as it will not be relevant
 						if (document.activeElement.nodeName === 'IFRAME') {


### PR DESCRIPTION
Per https://github.com/zotero/zotero/pull/4752#discussion_r1800481917, reader.ftl is simplified in https://github.com/zotero/zotero/pull/4756. This adds necessary logic to the reader to fetch necessary localized components and piece them together into an announcement.

Also, added zotero.ftl as another localization link, since without it general strings, such as `option-or-alt`, are not defined.

Followup to: https://github.com/zotero/zotero/commit/cde21ac9f2407856d000ea2038ea49cee7e8dd7c and https://github.com/zotero/reader/commit/d298f21bd9a3cc01f904d53d77646ecde3de1701