### PR TITLE
EPUB/Snapshot: Override print options to correct title & URL

### DIFF
--- a/src/dom/epub/epub-view.ts
+++ b/src/dom/epub/epub-view.ts
@@ -1064,7 +1064,21 @@ class EPUBView extends DOMView<EPUBViewState, EPUBViewData> {
 		);
 
 		if (typeof this._iframeWindow.zoteroPrint === 'function') {
-			await this._iframeWindow.zoteroPrint();
+			await this._iframeWindow.zoteroPrint({
+				overrideSettings: {
+					// Set title based on the book's title
+					title: this.book.packaging.metadata.title || '',
+					// Remove 'about:srcdoc' URL
+					docURL: '',
+					// And disable printing either of those things in the margins by default
+					headerStrLeft: '',
+					headerStrCenter: '',
+					headerStrRight: '',
+					footerStrLeft: '',
+					footerStrCenter: '',
+					footerStrRight: '',
+				}
+			});
 		}
 		else {
 			this._iframeWindow.print();

--- a/src/dom/snapshot/snapshot-view.ts
+++ b/src/dom/snapshot/snapshot-view.ts
@@ -94,7 +94,8 @@ class SnapshotView extends DOMView<SnapshotViewState, SnapshotViewData> {
 	getData() {
 		return {
 			srcDoc: this._iframe.srcdoc,
-			url: this._iframeDocument.head.querySelector('base')?.href
+			url: this._iframeDocument.head.querySelector('base')?.href,
+			importedFromURL: this._options.data.importedFromURL,
 		};
 	}
 
@@ -506,7 +507,11 @@ class SnapshotView extends DOMView<SnapshotViewState, SnapshotViewData> {
 
 	async print() {
 		if (typeof this._iframeWindow.zoteroPrint === 'function') {
-			await this._iframeWindow.zoteroPrint();
+			await this._iframeWindow.zoteroPrint({
+				overrideSettings: {
+					docURL: this._options.data.importedFromURL || '',
+				},
+			});
 		}
 		else {
 			this._iframeWindow.print();
@@ -524,6 +529,8 @@ export interface SnapshotViewState extends DOMViewState {
 
 export interface SnapshotViewData {
 	srcDoc?: string;
+	url?: string;
+	importedFromURL?: string;
 }
 
 export default SnapshotView;

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -5,7 +5,7 @@ declare interface Window {
 
 	DarkReader: typeof import('darkreader');
 
-	zoteroPrint?: () => Promise<void>;
+	zoteroPrint?: (options?: { overrideSettings?: Record<string, string> }) => Promise<void>;
 }
 
 declare interface Document {


### PR DESCRIPTION
EPUBs can show the book title (disabled by default) but don't have any URL. Snapshots show the page title and the URL they were imported from.

Needs https://github.com/zotero/zotero/pull/4820, fixes zotero/zotero#4818