### PR TITLE
Make annotations list lazy load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"queue": "^6.0.2",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
+				"react-intersection-observer": "^9.15.1",
 				"react-intl": "^7.0.1",
 				"sorted-btree": "^1.8.1"
 			},
@@ -15973,6 +15974,20 @@
 			},
 			"peerDependencies": {
 				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-intersection-observer": {
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz",
+			"integrity": "sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==",
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-intl": {
@@ -32456,6 +32471,12 @@
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
 			}
+		},
+		"react-intersection-observer": {
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz",
+			"integrity": "sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==",
+			"requires": {}
 		},
 		"react-intl": {
 			"version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"queue": "^6.0.2",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
+		"react-intersection-observer": "^9.15.1",
 		"react-intl": "^7.0.1",
 		"sorted-btree": "^1.8.1"
 	},

--- a/src/common/components/common/preview.js
+++ b/src/common/components/common/preview.js
@@ -1,5 +1,6 @@
 import React, { useContext, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useInView } from 'react-intersection-observer';
 import cx from 'classnames';
 import Editor from './editor';
 import ExpandableEditor from './expandable-editor';
@@ -137,6 +138,17 @@ export function SidebarPreview(props) {
 	const intl = useIntl();
 	const { platform } = useContext(ReaderContext);
 	const lastImageRef = useRef();
+
+	// Set up intersection observer
+	const { ref, inView } = useInView({
+		triggerOnce: true, // Only trigger once when the element comes into view.
+		threshold: 0,      // As soon as one pixel is visible.
+	});
+
+	// If the component is not in view on mount, render a placeholder.
+	if (!inView) {
+		return <div ref={ref} style={{ minHeight: '100px' }} />;
+	}
 
 	// Store and render the last image to avoid flickering when annotation manager removes
 	// old image, but the new one isn't generated yet
@@ -287,6 +299,7 @@ export function SidebarPreview(props) {
 
 	return (
 		<div
+			ref={ref}
 			onContextMenu={handleContextMenu}
 			className={cx('preview', {
 				'read-only': props.readOnly, ...expandedState


### PR DESCRIPTION
Make the annotations list lazy load with the package react-intersection-observer. Now the annotation in the SidebarPreview only renders when it becomes visible. For PDF file with more than 10k annotations, loading time for annotations list is significantly improved (from several seconds to immediately); for the Better Note plugin's annotation header custom button API call, the UI do nor freeze (previously freeze for several minutes).

I also tried react-virtualized, but due to the following reasons that would bring some issue that I don't think can be easily solved:
1. Since the annotation cells have dynamic height, the v-list's scroll-to does not promise a constant scrolling position, as the height of the previous cells would also affect the target cell's position
2. Since the dynamic height cell's height is only known after rendering, there will be a short intermediate state where the UI first show a cell with initial height. This brings bad UI experience. (Maybe there are workarounds, I tried with GPT/Claud but no luck)
3. The performance improvement is not significant comparing to the lazy load solution for me.

For the reasons above, I think we can just go with this PR and hopefully this will also decrease the memory usage of the reader.