### PR TITLE
Fix a race condition in `_updateColorScheme`

### DIFF
--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -447,7 +447,7 @@ class PDFView {
 		});
 	}
 
-	_updateColorScheme() {
+	async _updateColorScheme() {
 		if (this._forcedColorScheme === 'light') {
 			this._colorScheme = 'light';
 		}
@@ -482,6 +482,7 @@ class PDFView {
 			for (let page of this._pages) {
 				page.originalPage.reset();
 			}
+			await this._iframeWindow.PDFViewerApplication.initializedPromise;
 			this._iframeWindow.PDFViewerApplication.pdfViewer.update();
 			this._pdfThumbnails?.clear();
 		}


### PR DESCRIPTION
I've only noticed it happening in Safari, where it occurs every time, rendering Reader unusable. @mrtcode Please let me know if you think there might be any issue with this solution

Fixes zotero/web-library#602