### PR TITLE
Adapt Reader themes editing for web

### DIFF
--- a/src/common/components/modal-popup/appearance-popup.js
+++ b/src/common/components/modal-popup/appearance-popup.js
@@ -18,6 +18,7 @@ import IconSplitVertical from '../../../../res/icons/16/split-vertical.svg';
 import IconSpreadEven from '../../../../res/icons/16/spread-even.svg';
 import IconSpreadNone from '../../../../res/icons/16/spread-none.svg';
 import IconSpreadOdd from '../../../../res/icons/16/spread-odd.svg';
+import IconOptions from '../../../../res/icons/16/options.svg';
 import IconPlus from '../../../../res/icons/20/plus.svg';
 import { getCurrentColorScheme, getPopupCoordinatesFromClickEvent } from '../../lib/utilities';
 import { ReaderContext } from '../../reader';
@@ -165,6 +166,8 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 
 function Theme({ theme, active, onSet, onOpenContextMenu }) {
 	let intl = useIntl();
+	const isReadOnly = DEFAULT_THEMES.some(t => t.id === theme.id);
+	const { platform } = useContext(ReaderContext);
 
 	function handleClick(e) {
 		onSet(theme.id);
@@ -176,21 +179,47 @@ function Theme({ theme, active, onSet, onOpenContextMenu }) {
 		event.preventDefault();
 		let { x, y } = getPopupCoordinatesFromClickEvent(event);
 		onOpenContextMenu({ theme, x, y });
+
+		if(event.type === 'click') {
+			event.currentTarget.classList.add('context-menu-open');
+		}
 	}
 
 	let titleString = `pdfReader.theme.${theme.id}`;
 	let name = intl.messages[titleString] ? intl.formatMessage({ id: titleString }) : theme.label;
 
-	return (
-		<button
-			tabIndex={-1}
-			className={cx('theme', { active })}
-			style={{ backgroundColor: theme.background || '#ffffff', color: theme.foreground || '#000000' }}
-			title={name}
-			onClick={handleClick}
-			onContextMenu={handleContextMenu}
-		>{name}</button>
-	);
+	return platform === 'web'
+		? (
+			<div className={cx('theme', { active })} style={{ backgroundColor: theme.background || '#ffffff', color: theme.foreground || '#000000' }}>
+				<button
+					tabIndex={-1}
+					title={name}
+					onClick={handleClick}
+				>
+					{name}
+				</button>
+				{!isReadOnly && (
+					<button
+						title={intl.formatMessage({ id: 'pdfReader.themeOptions' }) }
+						tabIndex={-1}
+						className="theme-context-menu"
+						onClick={handleContextMenu}
+					>
+						<IconOptions />
+					</button>
+				)}
+			</div>
+		)
+		: (
+			<button
+				tabIndex={-1}
+				className={cx('theme', { active })}
+				style={{ backgroundColor: theme.background || '#ffffff', color: theme.foreground || '#000000' }}
+				title={name}
+				onClick={handleClick}
+				onContextMenu={handleContextMenu}
+			>{name}</button>
+		);
 }
 
 function AppearancePopup(props) {
@@ -363,15 +392,13 @@ function AppearancePopup(props) {
 										onOpenContextMenu={props.onOpenThemeContextMenu}
 									/>
 								))}
-								{platform !== 'web' && (
 									<button
-										tabIndex={-1}
-										className="theme add"
-										onClick={props.onAddTheme}
-										title={intl.formatMessage({ id: "pdfReader.addTheme" })}
-									><IconPlus/></button>
-								)}
-							</div>
+									tabIndex={-1}
+									className="theme add"
+									onClick={props.onAddTheme}
+									title={intl.formatMessage({ id: "pdfReader.addTheme" })}
+								><IconPlus/></button>
+								</div>
 						</div>
 					</div>
 				)}

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -1435,14 +1435,18 @@ class Reader {
 	setLightTheme(themeName) {
 		let themes = [...DEFAULT_THEMES, ...(this._state.customThemes || [])];
 		themes = new Map(themes.map(theme => [theme.id, theme]));
-		let lightTheme = themes.get(themeName) || null;
+		let lightTheme = themeName === undefined
+			? DEFAULT_THEMES.find(x => x.id === 'light')
+			: themes.get(themeName) || null;
 		this._updateState({ lightTheme });
 	}
 
 	setDarkTheme(themeName) {
 		let themes = [...DEFAULT_THEMES, ...(this._state.customThemes || [])];
 		themes = new Map(themes.map(theme => [theme.id, theme]));
-		let darkTheme = themes.get(themeName) || null;
+		let darkTheme = themeName === undefined
+			? DEFAULT_THEMES.find(x => x.id === 'dark')
+			: themes.get(themeName) || null;
 		this._updateState({ darkTheme });
 	}
 

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -735,6 +735,7 @@ class Reader {
 		this._updateState({ contextMenu: null });
 		this._focusManager.restoreFocus();
 		this._onBringReaderToFront?.(false);
+		document.querySelectorAll('.context-menu-open').forEach(x => x.classList.remove('context-menu-open'));
 	}
 
 	_handleAppearanceChange(params) {

--- a/src/common/stylesheets/components/_modal-popup.scss
+++ b/src/common/stylesheets/components/_modal-popup.scss
@@ -219,6 +219,7 @@
 			display: flex;
 			justify-content: center;
 			align-items: center;
+			position: relative;
 
 			&:active, &.active, &.active-pseudo-class-fix {
 				outline: 3px solid var(--accent-blue50);
@@ -226,6 +227,42 @@
 
 			&.add {
 				color: var(--fill-secondary);
+			}
+
+			> button {
+				width: 100%;
+				height: 100%;
+				text-align: center;
+			}
+
+			.theme-context-menu {
+				height: 18px;
+				opacity: 0;
+				position: absolute;
+				right: 2px;
+				top: 7px;
+				width: 18px;
+				border-radius: 4px;
+				padding: 1px;
+
+				svg {
+					transform: rotate(90deg);
+				}
+			}
+
+			&:hover, &:focus, &:focus-within {
+				.theme-context-menu {
+					opacity: 1;
+
+					&:focus {
+						background-color: rgba(0, 0, 0, .2);
+					}
+				}
+			}
+
+			.theme-context-menu.context-menu-open {
+				opacity: 1;
+				background-color: rgba(0, 0, 0, .2);
 			}
 		}
 	}

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -217,6 +217,7 @@ export default {
 	'pdfReader.single': 'Single',
 	'pdfReader.double': 'Double',
 	'pdfReader.themeName': 'Theme Name:',
+	'pdfReader.themeOptions': 'Theme Options',
 	'pdfReader.background': 'Background:',
 	'pdfReader.foreground': 'Foreground:',
 };


### PR DESCRIPTION
This restores the ability to add and edit themes in the web build and adapts the UI to follow the web library's paradigm of preserving the native context menu.

@mrtcode I've tried to keep the changes minimal and only related to the web build. Please let me know if you see any problems with these changes.

https://github.com/user-attachments/assets/a0404399-0f95-4e20-8082-cb7a33dde76a

