### PR TITLE
text annotation: support smaller font size

### DIFF
--- a/src/common/defines.js
+++ b/src/common/defines.js
@@ -42,7 +42,7 @@ export const INK_ANNOTATION_WIDTH_STEPS = [
 	19.5, 20, 20.5, 21, 21.5, 22, 22.5, 23, 23.5, 24, 24.5, 25
 ];
 
-export const TEXT_ANNOTATION_FONT_SIZE_STEPS = [10, 12, 14, 18, 24, 36, 48, 64, 72, 96, 144, 192];
+export const TEXT_ANNOTATION_FONT_SIZE_STEPS = [6, 7, 8, 9, 10, 12, 14, 18, 24, 36, 48, 64, 72, 96, 144, 192];
 
 export const DEFAULT_THEMES = [
 	{ id: 'dark', label: 'Dark', background: "#2E3440", foreground: "#D8DEE9" },


### PR DESCRIPTION
Hi,

Currently, the minimum font size of inline text annotation is 10. It's even bigger than the main font size used in some PDF papers, making it take more space to add inline text annotation directly on the paper.

I implemented this PR to enable the smaller font sizes of 6, 7, 8, and 9 for text annotation. 

There is also a request to decrease the text annotation font size in the Zotero forum: https://forums.zotero.org/discussion/120194/font-size-setting#latest

Please consider merging it!


