### PR TITLE
Snapshot: Add focus mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
+				"@abejellinek/readability-keep-nodes": "^1.0.0",
 				"classnames": "^2.3.1",
 				"darkreader": "^4.9.83",
 				"epubjs": "file:epubjs/epub.js",
@@ -400,6 +401,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@abejellinek/readability-keep-nodes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@abejellinek/readability-keep-nodes/-/readability-keep-nodes-1.0.0.tgz",
+			"integrity": "sha512-CCWqvDvkkXGLCLsm3Jjma6NUdV0TnxNdnjrewcW5R6lFBDdcGsOeBIsMbFwKyPghphmPaqwyIsuUAffzyKte/w==",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -20569,6 +20578,11 @@
 		}
 	},
 	"dependencies": {
+		"@abejellinek/readability-keep-nodes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@abejellinek/readability-keep-nodes/-/readability-keep-nodes-1.0.0.tgz",
+			"integrity": "sha512-CCWqvDvkkXGLCLsm3Jjma6NUdV0TnxNdnjrewcW5R6lFBDdcGsOeBIsMbFwKyPghphmPaqwyIsuUAffzyKte/w=="
+		},
 		"@ampproject/remapping": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"ff >= 60.9.0"
 	],
 	"dependencies": {
+		"@abejellinek/readability-keep-nodes": "^1.0.0",
 		"classnames": "^2.3.1",
 		"darkreader": "^4.9.83",
 		"epubjs": "file:epubjs/epub.js",

--- a/src/common/annotation-manager.js
+++ b/src/common/annotation-manager.js
@@ -13,7 +13,8 @@ class AnnotationManager {
 			query: '',
 			colors: [],
 			tags: [],
-			authors: []
+			authors: [],
+			hiddenIDs: [],
 		};
 		this._readOnly = options.readOnly;
 		this._authorName = options.authorName;
@@ -398,7 +399,12 @@ class AnnotationManager {
 		this._annotations.forEach(x => delete x._score);
 
 		let annotations = this._annotations.slice();
-		let { tags, colors, authors } = this._filter;
+		let { tags, colors, authors, query, hiddenIDs } = this._filter;
+
+		if (hiddenIDs.length) {
+			annotations = annotations.filter(x => !hiddenIDs.includes(x.id));
+		}
+
 		if (tags.length || colors.length || authors.length) {
 			annotations = annotations.filter(x => (
 				tags && x.tags.some(t => tags.includes(t.name))
@@ -407,9 +413,9 @@ class AnnotationManager {
 			));
 		}
 
-		if (this._filter.query) {
+		if (query) {
 			annotations = annotations.slice();
-			let query = this._filter.query.toLowerCase();
+			let query = query.toLowerCase();
 			let results = [];
 			for (let annotation of annotations) {
 				let errors = null;

--- a/src/common/components/modal-popup/appearance-popup.js
+++ b/src/common/components/modal-popup/appearance-popup.js
@@ -3,7 +3,7 @@ import cx from 'classnames';
 
 import IconRevert from '../../../../res/icons/16/revert.svg';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { DEFAULT_EPUB_APPEARANCE } from '../../../dom/epub/defines';
+import { DEFAULT_REFLOWABLE_APPEARANCE } from '../../../dom/common/defines';
 
 import IconColumnDouble from '../../../../res/icons/16/column-double.svg';
 import IconColumnSingle from '../../../../res/icons/16/column-single.svg';
@@ -18,14 +18,17 @@ import IconSplitVertical from '../../../../res/icons/16/split-vertical.svg';
 import IconSpreadEven from '../../../../res/icons/16/spread-even.svg';
 import IconSpreadNone from '../../../../res/icons/16/spread-none.svg';
 import IconSpreadOdd from '../../../../res/icons/16/spread-odd.svg';
+import IconX from '../../../../res/icons/16/x-8.svg';
 import IconOptions from '../../../../res/icons/16/options.svg';
 import IconPlus from '../../../../res/icons/20/plus.svg';
 import { getCurrentColorScheme, getPopupCoordinatesFromClickEvent } from '../../lib/utilities';
 import { ReaderContext } from '../../reader';
 import { DEFAULT_THEMES } from '../../defines';
 
-function EPUBAppearance({ params, enablePageWidth, onChange }) {
+function ReflowableAppearanceSection({ params, enablePageWidth, onChange }) {
 	const intl = useIntl();
+
+	const { type } = useContext(ReaderContext);
 
 	if (!params) {
 		// Not initialized yet - wait
@@ -43,12 +46,12 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 	}
 
 	function handleRevert(name) {
-		params[name] = DEFAULT_EPUB_APPEARANCE[name];
+		params[name] = DEFAULT_REFLOWABLE_APPEARANCE[name];
 		onChange(params);
 	}
 
 	return (
-		<div className="epub-appearance">
+		<div className="reflowable-appearance">
 			<div className="row">
 				<label htmlFor="line-height"><FormattedMessage id="pdfReader.epubAppearance.lineHeight"/></label>
 				<input
@@ -67,7 +70,7 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 				<button
 					data-tabstop={1}
 					tabIndex={-1}
-					className={cx('toolbar-button', { hidden: params.lineHeight === DEFAULT_EPUB_APPEARANCE.lineHeight })}
+					className={cx('toolbar-button', { hidden: params.lineHeight === DEFAULT_REFLOWABLE_APPEARANCE.lineHeight })}
 					aria-label={intl.formatMessage({ id: 'pdfReader.epubAppearance.lineHeight.revert' })}
 					onClick={() => handleRevert('lineHeight')}
 				><IconRevert/></button>
@@ -91,7 +94,7 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 				<button
 					data-tabstop={1}
 					tabIndex={-1}
-					className={cx('toolbar-button', { hidden: params.wordSpacing === DEFAULT_EPUB_APPEARANCE.wordSpacing })}
+					className={cx('toolbar-button', { hidden: params.wordSpacing === DEFAULT_REFLOWABLE_APPEARANCE.wordSpacing })}
 					aria-label={intl.formatMessage({ id: 'pdfReader.epubAppearance.wordSpacing.revert' })}
 					onClick={() => handleRevert('wordSpacing')}
 				><IconRevert/></button>
@@ -115,7 +118,7 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 				<button
 					data-tabstop={1}
 					tabIndex={-1}
-					className={cx('toolbar-button', { hidden: params.letterSpacing === DEFAULT_EPUB_APPEARANCE.letterSpacing })}
+					className={cx('toolbar-button', { hidden: params.letterSpacing === DEFAULT_REFLOWABLE_APPEARANCE.letterSpacing })}
 					aria-label={intl.formatMessage({ id: 'pdfReader.epubAppearance.letterSpacing.revert' })}
 					onClick={() => handleRevert('letterSpacing')}
 				><IconRevert/></button>
@@ -140,27 +143,29 @@ function EPUBAppearance({ params, enablePageWidth, onChange }) {
 				<button
 					data-tabstop={1}
 					tabIndex={-1}
-					className={cx('toolbar-button', { hidden: params.pageWidth === DEFAULT_EPUB_APPEARANCE.pageWidth })}
+					className={cx('toolbar-button', { hidden: params.pageWidth === DEFAULT_REFLOWABLE_APPEARANCE.pageWidth })}
 					aria-label={intl.formatMessage({ id: 'pdfReader.epubAppearance.pageWidth.revert' })}
 					onClick={() => handleRevert('pageWidth')}
 					disabled={!enablePageWidth}
 				><IconRevert/></button>
 			</div>
 
-			<div className="option">
+			{type === 'epub' && (
+				<div className="option">
 					<label htmlFor="use-original-font"><FormattedMessage
 						id="pdfReader.epubAppearance.useOriginalFont"/></label>
 					<input
 						data-tabstop={1}
-						tabIndex={-1}
-						className="switch"
+						tabIndex={-1}className="switch"
 						type="checkbox"
 						id="use-original-font"
 						name="useOriginalFont"
 						checked={params.useOriginalFont}
 						onChange={handleChange}
 					/>
-			</div>
+
+				</div>
+			)}
 		</div>
 	);
 }
@@ -363,11 +368,28 @@ function AppearancePopup(props) {
 						</div>
 					</div>
 				</div>
-				{type === 'epub' && (
+				{type === 'snapshot' && (
 					<div className="group">
-						<EPUBAppearance
+						<div className="option">
+							<label htmlFor="focus-mode-enabled"><FormattedMessage id="pdfReader.focusMode"/></label>
+							<input
+								data-tabstop={1}
+								tabIndex={-1}
+								className="switch"
+								type="checkbox"
+								id="focus-mode-enabled"
+								checked={props.viewStats.focusModeEnabled}
+								onChange={e => props.onChangeFocusModeEnabled(e.target.checked)}
+							/>
+						</div>
+					</div>
+				)}
+				{(type === 'epub' || type === 'snapshot' && props.viewStats.focusModeEnabled) && (
+					<div className="group">
+						<ReflowableAppearanceSection
 							params={props.viewStats.appearance}
-							enablePageWidth={props.viewStats.flowMode !== 'paginated' || props.viewStats.spreadMode === 0}
+							enablePageWidth={type === 'snapshot'
+								|| props.viewStats.flowMode !== 'paginated' || props.viewStats.spreadMode === 0}
 							onChange={props.onChangeAppearance}
 						/>
 					</div>

--- a/src/common/components/reader-ui.js
+++ b/src/common/components/reader-ui.js
@@ -230,6 +230,7 @@ const ReaderUI = React.forwardRef((props, ref) => {
 					onChangeSpreadMode={props.onChangeSpreadMode}
 					onChangeFlowMode={props.onChangeFlowMode}
 					onChangeAppearance={props.onChangeAppearance}
+					onChangeFocusModeEnabled={props.onChangeFocusModeEnabled}
 					onAddTheme={props.onAddTheme}
 					onChangeTheme={props.onChangeTheme}
 					onOpenThemeContextMenu={props.onOpenThemeContextMenu}

--- a/src/common/stylesheets/components/_modal-popup.scss
+++ b/src/common/stylesheets/components/_modal-popup.scss
@@ -389,7 +389,7 @@
 		}
 	}
 
-	.epub-appearance {
+	.reflowable-appearance {
 		display: flex;
 		flex-direction: column;
 		gap: 12px;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,5 @@
 import { Selector } from "../dom/common/lib/selector";
-import { EPUBAppearance } from "../dom/epub/epub-view";
+import { ReflowableAppearance } from "../dom/common/dom-view";
 
 export type ToolType =
 	| 'highlight'
@@ -110,9 +110,10 @@ export type ViewStats = {
 	scrollMode?: number;
 	spreadMode?: number;
 	flowMode?: string;
-	appearance?: Partial<EPUBAppearance>;
+	appearance?: Partial<ReflowableAppearance>;
 	fontFamily?: string;
 	outlinePath?: number[];
+	focusModeEnabled?: boolean;
 };
 
 export type AnnotationPopupParams<A extends Annotation = Annotation> = {
@@ -146,7 +147,11 @@ type ImagePopupParams = {
 	rect: ArrayRect;
 }
 
-export type OverlayPopupParams = FootnotePopupParams | LinkPopupParams | ImagePopupParams
+type HiddenInFocusModeParams = {
+	type: 'hiddenInFocusMode';
+}
+
+export type OverlayPopupParams = FootnotePopupParams | LinkPopupParams | ImagePopupParams | HiddenInFocusModeParams;
 
 export type ArrayRect = [left: number, top: number, right: number, bottom: number];
 

--- a/src/dom/common/defines.ts
+++ b/src/dom/common/defines.ts
@@ -1,0 +1,9 @@
+import { PageWidth, ReflowableAppearance } from "./dom-view";
+
+export const DEFAULT_REFLOWABLE_APPEARANCE: ReflowableAppearance = Object.freeze({
+	lineHeight: 1.2,
+	wordSpacing: 0,
+	letterSpacing: 0,
+	pageWidth: PageWidth.Normal,
+	useOriginalFont: false,
+});

--- a/src/dom/common/lib/collection.ts
+++ b/src/dom/common/lib/collection.ts
@@ -12,3 +12,10 @@ export function mode<T>(iter: Iterable<T>): T | undefined {
 	}
 	return maxValue;
 }
+
+export function* enumerate<T>(iter: Iterable<T>): Iterable<[number, T]> {
+	let i = 0;
+	for (let value of iter) {
+		yield [i++, value];
+	}
+}

--- a/src/dom/common/lib/nodes.ts
+++ b/src/dom/common/lib/nodes.ts
@@ -73,15 +73,27 @@ export function getContainingBlock(element: Element): Element | null {
 	return null;
 }
 
-export function iterateWalker(walker: TreeWalker | NodeIterator): Iterable<Node> {
-	return {
-		[Symbol.iterator]: function* () {
-			let node: Node | null;
-			while ((node = walker.nextNode())) {
-				yield node;
+export function iterateWalker(walker: TreeWalker | NodeIterator, direction: 'forward' | 'backward' = 'forward'): Iterable<Node> {
+	if (direction === 'forward') {
+		return {
+			[Symbol.iterator]: function* () {
+				let node: Node | null;
+				while ((node = walker.nextNode())) {
+					yield node;
+				}
 			}
-		}
-	};
+		};
+	}
+	else {
+		return {
+			[Symbol.iterator]: function* () {
+				let node: Node | null;
+				while ((node = walker.previousNode())) {
+					yield node;
+				}
+			}
+		};
+	}
 }
 
 export function isRTL(node: Node): boolean {

--- a/src/dom/common/lib/selector.ts
+++ b/src/dom/common/lib/selector.ts
@@ -73,9 +73,9 @@ export function isSelector(maybeSelector: any): maybeSelector is Selector {
 	return isFragment(selector) || isCss(selector) || isTextQuote(selector) || isTextPosition(selector);
 }
 
-export function textPositionFromRange(range: Range, root: Element): TextPositionSelector | null {
+export function textPositionFromRange(range: Range, root: Node): TextPositionSelector | null {
 	range = moveRangeEndsIntoTextNodes(range);
-	let iter = root.ownerDocument.createNodeIterator(root, NodeFilter.SHOW_TEXT);
+	let iter = root.ownerDocument!.createNodeIterator(root, NodeFilter.SHOW_TEXT);
 	let selector: Partial<TextPositionSelector> = {
 		type: 'TextPositionSelector'
 	};

--- a/src/dom/common/lib/unique-selector.ts
+++ b/src/dom/common/lib/unique-selector.ts
@@ -1,34 +1,27 @@
-import { closestElement } from "./nodes";
-
 /**
- * Generate a CSS selector uniquely pointing to node's closest Element ancestor, relative to root.
+ * Generate a CSS selector uniquely pointing to the element, relative to root.
  */
-export function getUniqueSelectorContaining(node: Node, root: Element): string | null {
-	let doc = node.ownerDocument;
-	if (!doc) {
-		return null;
+export function getUniqueSelectorContaining(element: Element): string | null {
+	let root = element.closest('body');
+	if (!root) {
+		throw new Error('Element has no body ancestor');
 	}
-	// Get the closest element to the node (which may be the node itself)
-	let element = closestElement(node);
-	if (!element) {
-		return null;
-	}
-	let originalElement = element;
 
 	let testSelector = (selector: string) => {
-		return root.querySelectorAll(selector).length == 1 && root.querySelector(selector) == originalElement;
+		return root.querySelectorAll(selector).length == 1 && root.querySelector(selector) == element;
 	};
 
+	let currentElement: Element | null = element;
 	let selector = '';
-	while (element && element !== root) {
+	while (currentElement && currentElement !== root) {
 		let joiner = selector ? ' > ' : '';
-		if (element.id) {
-			return `#${CSS.escape(element.id)}` + joiner + selector;
+		if (currentElement.id) {
+			return `#${CSS.escape(currentElement.id)}` + joiner + selector;
 		}
 
-		let tagName = element.tagName.toLowerCase();
+		let tagName = currentElement.tagName.toLowerCase();
 
-		let prevSibling = element.previousElementSibling;
+		let prevSibling = currentElement.previousElementSibling;
 		if (prevSibling && prevSibling.id) {
 			let prevSiblingIDSelector = `#${CSS.escape(prevSibling.id)} + ${tagName}${joiner}${selector}`;
 			if (testSelector(prevSiblingIDSelector)) {
@@ -37,23 +30,23 @@ export function getUniqueSelectorContaining(node: Node, root: Element): string |
 		}
 
 		let childPseudoclass;
-		if (element.matches(':only-of-type') || element.matches(':only-child')) {
+		if (currentElement.matches(':only-of-type') || currentElement.matches(':only-child')) {
 			childPseudoclass = '';
 		}
-		else if (element.matches(':first-child')) {
+		else if (currentElement.matches(':first-child')) {
 			childPseudoclass = ':first-child';
 		}
-		else if (element.matches(':first-of-type')) {
+		else if (currentElement.matches(':first-of-type')) {
 			childPseudoclass = ':first-of-type';
 		}
-		else if (element.matches(':last-child')) {
+		else if (currentElement.matches(':last-child')) {
 			childPseudoclass = ':last-child';
 		}
-		else if (element.matches(':last-of-type')) {
+		else if (currentElement.matches(':last-of-type')) {
 			childPseudoclass = ':last-of-type';
 		}
-		else if (element.parentElement) {
-			childPseudoclass = `:nth-child(${[...element.parentElement.children].indexOf(element) + 1})`;
+		else if (currentElement.parentElement) {
+			childPseudoclass = `:nth-child(${[...currentElement.parentElement.children].indexOf(currentElement) + 1})`;
 		}
 		else {
 			break;
@@ -65,7 +58,7 @@ export function getUniqueSelectorContaining(node: Node, root: Element): string |
 			return selector;
 		}
 
-		element = element.parentElement;
+		currentElement = currentElement.parentElement;
 	}
 	return null;
 }

--- a/src/dom/epub/defines.ts
+++ b/src/dom/epub/defines.ts
@@ -1,5 +1,3 @@
-import { EPUBAppearance, PageWidth } from "./epub-view";
-
 export const EPUB_LOCATION_BREAK_INTERVAL = 1800;
 
 // RTL script codes
@@ -20,13 +18,5 @@ export const RTL_SCRIPTS = new Set([
 	'Thaa',
 	'Yezi',
 ]);
-
-export const DEFAULT_EPUB_APPEARANCE: EPUBAppearance = Object.freeze({
-	lineHeight: 1.2,
-	wordSpacing: 0,
-	letterSpacing: 0,
-	pageWidth: PageWidth.Normal,
-	useOriginalFont: false,
-});
 
 export const A11Y_VIRT_CURSOR_DEBOUNCE_LENGTH = 500;

--- a/src/dom/epub/lib/sanitize-and-render.ts
+++ b/src/dom/epub/lib/sanitize-and-render.ts
@@ -282,6 +282,7 @@ export class CSSRewriter {
 			let style = styleRule.style;
 
 			if (style.display === 'table' || style.display === 'inline-table') {
+				console.log(styleRule.selectorText)
 				this.trackedSelectors.table.add(styleRule.selectorText);
 			}
 			if (style.verticalAlign === 'super') {

--- a/src/dom/snapshot/focus-mode/index.ts
+++ b/src/dom/snapshot/focus-mode/index.ts
@@ -1,0 +1,175 @@
+import focusSCSS from '../stylesheets/focus.scss';
+import { Readability } from "@abejellinek/readability-keep-nodes";
+import { iterateWalker } from "../../common/lib/nodes";
+import { enumerate } from "../../common/lib/collection";
+import { NodeMapping } from "./node-mapping";
+
+export class FocusMode {
+	private readonly _doc: Document;
+
+	private readonly _mapping = new NodeMapping();
+
+	private readonly _fragment: DocumentFragment;
+
+	private readonly _originalStyleSheets = new Map<CSSStyleSheet, Element | ProcessingInstruction | null>;
+
+	private readonly _focusStyle: HTMLStyleElement;
+
+	private _enabled = false;
+
+	constructor(doc: Document) {
+		this._doc = doc;
+		this._fragment = doc.createDocumentFragment();
+		this._focusStyle = doc.createElement('style');
+		this._focusStyle.textContent = focusSCSS;
+
+		for (let styleSheet of [...this._doc.styleSheets, ...this._doc.adoptedStyleSheets]) {
+			if (styleSheet.disabled) {
+				continue;
+			}
+			this._originalStyleSheets.set(styleSheet, styleSheet.ownerNode);
+		}
+	}
+
+	get enabled() {
+		return this._enabled;
+	}
+
+	set enabled(enabled: boolean) {
+		if (enabled === this._enabled) {
+			return;
+		}
+		if (enabled) {
+			this._enable();
+		}
+		else {
+			this._disable();
+		}
+		this._enabled = enabled;
+	}
+
+	get originalRoot(): DocumentFragment {
+		if (!this._enabled) {
+			throw new Error('Not enabled');
+		}
+		return this._fragment;
+	}
+
+	mapNodeToFocus(node: Node) {
+		if (!this._enabled) {
+			throw new Error('Not enabled');
+		}
+		let mappedNode = this._mapping.getByPre(node);
+		if (!mappedNode || !this._doc.body.contains(mappedNode)) {
+			return null;
+		}
+		return mappedNode;
+	}
+
+	mapRangeToFocus(range: Range) {
+		let startContainer = this.mapNodeToFocus(range.startContainer);
+		let endContainer = this.mapNodeToFocus(range.endContainer);
+		if (!startContainer || !endContainer) {
+			return null;
+		}
+		let newRange = this._doc.createRange();
+		newRange.setStart(startContainer, range.startOffset);
+		newRange.setEnd(endContainer, range.endOffset);
+		return newRange;
+	}
+
+	mapNodeFromFocus(node: Node) {
+		if (!this._enabled) {
+			throw new Error('Not enabled');
+		}
+		let mappedNode = this._mapping.getByPost(node);
+		if (!mappedNode || !this._fragment.contains(mappedNode)) {
+			return null;
+		}
+		return mappedNode;
+	}
+
+	mapRangeFromFocus(range: Range) {
+		let startContainer = this.mapNodeFromFocus(range.startContainer);
+		let endContainer = this.mapNodeFromFocus(range.endContainer);
+		if (!startContainer || !endContainer) {
+			return null;
+		}
+		let newRange = this._doc.createRange();
+		newRange.setStart(startContainer, range.startOffset);
+		newRange.setEnd(endContainer, range.endOffset);
+		return newRange;
+	}
+
+	private _enable() {
+		let initMapping = () => {
+			let clonedDoc = this._doc.cloneNode(true) as Document;
+
+			let originalNodes = [...iterateWalker(this._doc.createTreeWalker(this._doc.body, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT))];
+			for (let [i, mappedNode] of enumerate(iterateWalker(clonedDoc.createTreeWalker(clonedDoc.body, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT)))) {
+				this._mapping.setByPre(originalNodes[i], mappedNode);
+			}
+
+			let fragmentBody = this._doc.createElement('body');
+			for (let child of [...this._doc.body.childNodes]) {
+				if (child.nodeType === Node.ELEMENT_NODE && (child as Element).id === 'annotation-overlay') {
+					continue;
+				}
+				fragmentBody.append(child);
+			}
+			this._fragment.replaceChildren(fragmentBody);
+
+			return clonedDoc;
+		};
+
+		let clonedDoc = initMapping();
+		let readability = new Readability(clonedDoc, {
+			serializer: node => node,
+			reload: () => {
+				this._disable();
+				clonedDoc = initMapping();
+				return clonedDoc;
+			},
+		});
+		Object.defineProperty(readability, '_setNodeTag', {
+			value: (node: Node, _newTagName: string) => {
+				// We don't really care about the element changes Readability wants to make
+				// (mostly h1 -> h2), and letting it make them would break our mappings
+				return node;
+			}
+		});
+		Object.defineProperty(readability, '_fixRelativeUris', {
+			value: () => {
+				// Leave links alone - we've already handled them
+			}
+		});
+		let root = readability.parse()?.content;
+		if (!root) {
+			throw new Error('Readability failed');
+		}
+		this._doc.body.prepend(root);
+
+		for (let [styleSheet, ownerNode] of this._originalStyleSheets) {
+			styleSheet.disabled = true;
+			ownerNode?.remove();
+		}
+		this._doc.head.append(this._focusStyle);
+	}
+
+	private _disable() {
+		this._doc.body.replaceChildren(
+			...this._fragment.firstElementChild!.childNodes,
+			this._doc.body.querySelector(':scope > #annotation-overlay')!,
+		);
+
+		for (let [styleSheet, ownerNode] of this._originalStyleSheets) {
+			styleSheet.disabled = false;
+			if (ownerNode) {
+				this._doc.head.append(ownerNode);
+			}
+		}
+		this._focusStyle.remove();
+		this._mapping.clear();
+		this._fragment.replaceChildren();
+	}
+}

--- a/src/dom/snapshot/focus-mode/node-mapping.ts
+++ b/src/dom/snapshot/focus-mode/node-mapping.ts
@@ -1,0 +1,79 @@
+export class NodeMapping {
+	private readonly _preToPost = new Map<Node, Node>();
+
+	private readonly _postToPre = new Map<Node, Node>();
+
+	get size() {
+		return this._preToPost.size;
+	}
+
+	[Symbol.iterator](): MapIterator<[Node, Node]> {
+		return this._preToPost[Symbol.iterator]();
+	}
+
+	clear(): void {
+		this._preToPost.clear();
+		this._postToPre.clear();
+	}
+
+	deleteByPre(preKey: Node): boolean {
+		if (!this._preToPost.has(preKey)) {
+			return false;
+		}
+		let postKey = this._preToPost.get(preKey);
+		this._preToPost.delete(preKey);
+		this._postToPre.delete(postKey!);
+		return true;
+	}
+
+	deleteByPost(postKey: Node): boolean {
+		if (!this._postToPre.has(postKey)) {
+			return false;
+		}
+		let preKey = this._postToPre.get(postKey);
+		this._preToPost.delete(preKey!);
+		this._postToPre.delete(postKey);
+		return true;
+	}
+
+	entries(): MapIterator<[Node, Node]> {
+		return this._preToPost.entries();
+	}
+
+	forEach(callbackfn: (value: Node, key: Node, map: Map<Node, Node>) => void, thisArg?: any): void {
+		this._preToPost.forEach(callbackfn, thisArg);
+	}
+
+	getByPre(preKey: Node): Node | undefined {
+		return this._preToPost.get(preKey);
+	}
+
+	getByPost(postKey: Node): Node | undefined {
+		return this._postToPre.get(postKey);
+	}
+
+	hasByPre(preKey: Node): boolean {
+		return this._preToPost.has(preKey);
+	}
+
+	hasByPost(postKey: Node): boolean {
+		return this._postToPre.has(postKey);
+	}
+
+	preKeys(): MapIterator<Node> {
+		return this._preToPost.keys();
+	}
+
+	postKeys(): MapIterator<Node> {
+		return this._postToPre.keys();
+	}
+
+	setByPre(preKey: Node, postKey: Node): this {
+		if (preKey.getRootNode() === postKey.getRootNode()) {
+			throw new Error('Nodes are in same root');
+		}
+		this._preToPost.set(preKey, postKey);
+		this._postToPre.set(postKey, preKey);
+		return this;
+	}
+}

--- a/src/dom/snapshot/stylesheets/focus.scss
+++ b/src/dom/snapshot/stylesheets/focus.scss
@@ -1,0 +1,75 @@
+:root {
+	&:not(.use-original-font) {
+		font-family: var(--content-font-family, "Georgia", serif);
+	}
+	text-align: justify;
+	text-rendering: optimizeLegibility;
+
+	// https://readium.org/readium-css/docs/CSS08-defaults.html#dynamic-leading-line-height
+	--content-line-height-compensation: 1;
+	--content-line-height: calc(
+		(1em + (2ex - 1ch) - ((1rem - 16px) * 0.1667))
+		* var(--content-line-height-compensation)
+		* var(--content-line-height-adjust, 1.2)
+	);
+	--content-word-spacing: calc(var(--content-word-spacing-adjust, 0) * 1%);
+	--content-letter-spacing: calc(var(--content-letter-spacing-adjust, 0) * 1em);
+
+	font-size: 1.1rem;
+	font-family: Georgia, serif;
+	background-color: var(--background-color);
+	color: var(--text-color);
+
+	--link-color: #0000ee;
+	--visited-link-color: #551a8b;
+
+	&[data-color-scheme="dark"] {
+		--link-color: #63caff;
+		--visited-link-color: #0099e5;
+	}
+}
+
+body {
+	margin-inline: auto;
+	padding: 3rem;
+
+	:root[data-page-width="narrow"] & {
+		max-inline-size: 650px;
+	}
+
+	:root[data-page-width="normal"] & {
+		max-inline-size: 800px;
+	}
+
+	:root[data-page-width="full"] & {
+		max-inline-size: 100%;
+	}
+
+	:root.hyphenate & {
+		hyphens: auto;
+	}
+
+	&, * {
+		line-height: var(--content-line-height);
+		word-spacing: var(--content-word-spacing);
+		letter-spacing: var(--content-letter-spacing);
+	}
+}
+
+img, svg {
+	max-width: 100%;
+}
+
+:link {
+	color: var(--link-color);
+}
+
+:visited {
+	color: var(--visited-link-color);
+}
+
+h1, h2, h3, h4, h5, h6 {
+	text-align: start;
+	text-wrap: balance;
+	hyphens: none !important;
+}

--- a/src/en-us.strings.js
+++ b/src/en-us.strings.js
@@ -221,4 +221,6 @@ export default {
 	'pdfReader.themeOptions': 'Theme Options',
 	'pdfReader.background': 'Background:',
 	'pdfReader.foreground': 'Foreground:',
+	'pdfReader.focusMode': 'Focus Mode',
+	'pdfReader.focusMode.notSupported': 'Focus Mode is not supported for this snapshot.',
 };


### PR DESCRIPTION
Enable it from the Appearance popup. (Icons obviously not final.)

All annotation tools are supported with focus mode enabled, and I haven't noticed any issues with mapping between focus and non-focus so far, but it's a tricky problem - things might come up.

Only tested in the browser.

Fixes zotero/zotero#5003