### PR TITLE
Fix initializedPromise never resolve in Zotero Reader

### DIFF
--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -273,6 +273,11 @@ class Reader {
 
 		this._primaryView = this._createView(true, options.location);
 
+		// Resolve the Reader's initializedPromise after the primary view is initialized
+		this._primaryView.initializedPromise.then(() => {
+			this._resolveInitializedPromise();
+		});
+
 		if (selectAnnotationID) {
 			(async () => {
 				await this._primaryView.initializedPromise;


### PR DESCRIPTION
Hello,

While working on a tool with the Zotero Reader, I noticed that the `initializedPromise` was never resolving. This caused any await calls on it to hang indefinitely.

To address this, I added a call to `_resolveInitializedPromise` after the primary view is initialized. I believe this is an appropriate place for it, but please let me know if there’s a better location or if you have any questions or concerns.

Thanks!