### PR TITLE
Add ESM Build & Demo

### DIFF
--- a/demo/esm.html
+++ b/demo/esm.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Zotero Reader Module</title>
+  <link rel="stylesheet" href="./reader.css" />
+</head>
+<body>
+  <div id="reader-root"></div>
+
+  <script type="module">
+    import Reader from '/reader.mjs';
+    import epubAnnotations from '/epub/annotations.js';
+    import pdfAnnotations from '/pdf/annotations.js';
+    import snapshotAnnotations from '/snapshot/annotations.js';
+
+    const annotationsMap = {
+      epub: epubAnnotations,
+      pdf: pdfAnnotations,
+      snapshot: snapshotAnnotations
+    };
+
+    const files = {
+      epub: '/epub/demo.epub',
+      pdf: '/pdf/demo.pdf',
+      snapshot: '/snapshot/demo.html'
+    };
+
+    const params = new URLSearchParams(window.location.search);
+    const type = params.get('type') || 'epub';
+
+    const annotations = annotationsMap[type];
+    const file = files[type];
+
+    const container = document.getElementById('reader-root');
+    if (!container) throw new Error('Container #reader-root not found');
+
+    // Create DOM structure expected by Reader
+    const readerUI = document.createElement('div');
+    readerUI.id = 'reader-ui';
+
+    const splitView = document.createElement('div');
+    splitView.id = 'split-view';
+
+    const primaryView = document.createElement('div');
+    primaryView.id = 'primary-view';
+    primaryView.className = 'primary-view';
+
+    const secondaryView = document.createElement('div');
+    secondaryView.id = 'secondary-view';
+    secondaryView.className = 'secondary-view';
+
+    splitView.append(primaryView, secondaryView);
+
+    const printContainer = document.createElement('div');
+    printContainer.id = 'printContainer';
+
+    container.append(readerUI, splitView, printContainer);
+
+    let reader;
+
+    const init = async () => {
+      const res = await fetch(file);
+      const buf = new Uint8Array(await res.arrayBuffer());
+
+      reader = new Reader({
+        container,
+        type,
+        readOnly: false,
+        data: {
+          buf,
+          url: location.origin + '/'
+        },
+        annotations,
+        sidebarWidth: 240,
+        authorName: 'John',
+        showAnnotations: true,
+        onOpenContextMenu(params) {
+          reader.openContextMenu(params);
+        },
+        onChangeViewState(state, primary) {
+          console.log('View state changed:', state, primary);
+        }
+      });
+
+      await reader.initializedPromise;
+      reader.enableAddToNote(true);
+      window._reader = reader;
+
+      console.log(`Reader initialized with type: ${type}`);
+    };
+
+    init().catch(err => {
+      console.error(err);
+      alert('Failed to initialize reader: ' + err.message);
+    });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"build:ios": "webpack --config-name ios",
 		"build:android": "webpack --config-name android",
 		"start": "webpack-dev-server --mode development --config-name dev",
+		"start:esm": "webpack-dev-server --config-name esm",
 		"view-dev": "webpack-dev-server --mode development --config-name view-dev",
 		"test": "echo \"No tests yet\""
 	},

--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -1,0 +1,5 @@
+import './common/stylesheets/main.scss';
+import Reader from './common/reader';
+
+export { Reader };
+export default Reader;


### PR DESCRIPTION
I’ve been experimenting with ESM support for the Reader module to make it easier to import into other apps, like Vite projects, using native `import`. The most notable change here is to the `build:reader` logic in the webpack config — it now supports an `esm` target that outputs a proper `reader.mjs` with module support.

I also added a simple `demo/esm.html` file to test the output directly in the browser without bundlers. It supports switching between `epub`, `pdf`, and `snapshot` via query param. `epub` and `snapshot` load fine with annotations, but PDF is still broken (likely due to PDF.js quirks in ESM). Still early, just putting this up to share progress and get early thoughts.
