### PR TITLE
Do not override key of annotation when restoring from trash

### DIFF
--- a/src/common/annotation-manager.js
+++ b/src/common/annotation-manager.js
@@ -23,6 +23,7 @@ class AnnotationManager {
 		this._onSave = options.onSave;
 		this._onDelete = options.onDelete;
 		this._onChangeHistory = options.onChangeHistory;
+		this._trashesAnnotations = options.trashesAnnotations;
 		this._adjustTextAnnotationPosition = options.adjustTextAnnotationPosition;
 		this.render = () => {
 			options.onRender([...this._annotations]);
@@ -601,8 +602,10 @@ class AnnotationManager {
 			if (annotation) {
 				annotation.dateModified = (new Date()).toISOString();
 			}
-			// Assign new id when undeleting to reduce sync conflicts
-			if (!prevAnnotation) {
+			// Assign new id when undeleting to reduce sync conflicts. Clients that
+			// trash annotations keep the deleted one around, so undeleting restores
+			// it in place and the id has to stay the same for the client to find it.
+			if (!prevAnnotation && !this._trashesAnnotations) {
 				let newID = this._generateObjectKey();
 				mapping.set(annotation.id, newID);
 				annotation.id = newID;
@@ -635,8 +638,10 @@ class AnnotationManager {
 			if (annotation) {
 				annotation.dateModified = (new Date()).toISOString();
 			}
-			// Assign new id when undeleting to reduce sync conflicts
-			if (!prevAnnotation) {
+			// Assign new id when undeleting to reduce sync conflicts. Clients that
+			// trash annotations keep the deleted one around, so undeleting restores
+			// it in place and the id has to stay the same for the client to find it.
+			if (!prevAnnotation && !this._trashesAnnotations) {
 				let newID = this._generateObjectKey();
 				mapping.set(annotation.id, newID);
 				annotation.id = newID;
@@ -652,6 +657,12 @@ class AnnotationManager {
 		this.render();
 		this._notifyChangeHistory();
 		return true;
+	}
+
+	// Drops history points for annotations that have left the reader so
+	// that erased annotations cannot be brought back.
+	clearHistoryForAnnotations(ids) {
+		this._clearInterferingHistory(ids);
 	}
 
 	_clearInterferingHistory(affectedAnnotationIDs) {

--- a/src/common/annotation-manager.js
+++ b/src/common/annotation-manager.js
@@ -605,9 +605,10 @@ class AnnotationManager {
 			if (annotation) {
 				annotation.dateModified = (new Date()).toISOString();
 			}
-			// Assign new id when undeleting to reduce sync conflicts. Clients that
-			// trash annotations keep the deleted one around, so undeleting restores
-			// it in place and the id has to stay the same for the client to find it.
+			// Assign a new ID when undeleting to reduce sync conflicts,
+			// except if the client trashes instead of permanently deleting -
+			// in that case, keep the old ID so the client can match the
+			// trashed annotation and untrash it.
 			if (!prevAnnotation && !this._trashesAnnotations) {
 				let newID = this._generateObjectKey();
 				mapping.set(annotation.id, newID);

--- a/src/common/annotation-manager.js
+++ b/src/common/annotation-manager.js
@@ -63,14 +63,17 @@ class AnnotationManager {
 	}
 
 	// Called when deletions come from the client side
-	unsetAnnotations(ids) {
+	unsetAnnotations(ids, permanentlyDeleted) {
 		// Deletions we haven't applied yet are outside changes that our history
 		// can no longer be replayed over. Ones we have applied are our own
-		// deletions coming back to us, and undoing them is still valid.
-		let externalIDs = ids.filter(id => this._annotations.some(x => x.id === id));
+		// deletions coming back to us, and undoing them is still valid, unless
+		// the annotations were permanently deleted.
+		let clearIDs = permanentlyDeleted
+			? ids
+			: ids.filter(id => this._annotations.some(x => x.id === id));
 		this._annotations = this._annotations.filter(x => !ids.includes(x.id));
-		if (externalIDs.length) {
-			this._clearInterferingHistory(externalIDs);
+		if (clearIDs.length) {
+			this._clearInterferingHistory(clearIDs);
 		}
 		this.render();
 	}
@@ -657,12 +660,6 @@ class AnnotationManager {
 		this.render();
 		this._notifyChangeHistory();
 		return true;
-	}
-
-	// Drops history points for annotations that have left the reader so
-	// that erased annotations cannot be brought back.
-	clearHistoryForAnnotations(ids) {
-		this._clearInterferingHistory(ids);
 	}
 
 	_clearInterferingHistory(affectedAnnotationIDs) {

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -949,15 +949,8 @@ class Reader {
 		this._annotationManager.setAnnotations(annotations);
 	}
 
-	unsetAnnotations(ids) {
-		this._annotationManager.unsetAnnotations(ids);
-	}
-
-	// Called when the client permanently deletes annotations that are no longer
-	// in the view (e.g. erased from the trash), so history points referencing
-	// them can't be replayed and recreate them
-	clearAnnotationsHistory(ids) {
-		this._annotationManager.clearHistoryForAnnotations(ids);
+	unsetAnnotations(ids, permanentlyDeleted) {
+		this._annotationManager.unsetAnnotations(ids, permanentlyDeleted);
 	}
 
 	openContextMenu(params) {

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -130,6 +130,7 @@ class Reader {
 		this._onSetPopupPosition = options.onSetPopupPosition;
 		this._onChangeUndoHistory = options.onChangeUndoHistory;
 		this._externalUndoHistory = !!options.onChangeUndoHistory;
+		this._trashesAnnotations = !!options.trashesAnnotations;
 
 		for (let ftl of options.ftl) {
 			addFTL(ftl);
@@ -361,6 +362,7 @@ class Reader {
 				this._updateState({ filter });
 			},
 			onChangeHistory: this._onChangeUndoHistory,
+			trashesAnnotations: this._trashesAnnotations,
 			adjustTextAnnotationPosition: (annotation, option) => {
 				return this._primaryView.adjustTextAnnotationPosition(annotation, option);
 			}
@@ -949,6 +951,13 @@ class Reader {
 
 	unsetAnnotations(ids) {
 		this._annotationManager.unsetAnnotations(ids);
+	}
+
+	// Called when the client permanently deletes annotations that are no longer
+	// in the view (e.g. erased from the trash), so history points referencing
+	// them can't be replayed and recreate them
+	clearAnnotationsHistory(ids) {
+		this._annotationManager.clearHistoryForAnnotations(ids);
 	}
 
 	openContextMenu(params) {


### PR DESCRIPTION
Since now annotation items will just be un-deleted vs erased and recreated on `undo`.

Needed for https://github.com/zotero/zotero/pull/5472