### PR TITLE
fix one letter search pop-up behaviour

### DIFF
--- a/src/common/components/view-popup/find-popup.js
+++ b/src/common/components/view-popup/find-popup.js
@@ -55,20 +55,26 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 	function handleInputKeyDown(event) {
 		let key = getKeyCombination(event);
 		let code = getCodeCombination(event);
+
+		let actualQuery = inputRef.current.value;
+		let queryChanged = (
+			actualQuery !== currentParamsRef.current.query
+		);
+
 		if (key === 'Enter') {
-			if (params.active) {
+			if (params.active && !queryChanged) {
 				onFindNext();
-			}
-			else {
-				onChange({ ...params, active: true });
+			} else {
+				setQuery(actualQuery);
+				onChange({ ...params, query:actualQuery, active: true });
 			}
 		}
 		else if (key === 'Shift-Enter') {
-			if (params.active) {
+			if (params.active && !queryChanged) {
 				onFindPrevious();
-			}
-			else {
-				onChange({ ...params, active: true });
+			} else {
+				setQuery(actualQuery);
+				onChange({ ...params, query:actualQuery, active: true });
 			}
 		}
 		else if (key === 'Escape') {
@@ -76,7 +82,7 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 			event.preventDefault();
 			event.stopPropagation();
 		}
-		else if (code === 'Ctrl-Alt-Digit1') {
+		else if (code === 'Ctrl-Alt-Digit1' && !queryChanged) {
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
 				onAddAnnotation({ ...params.result.annotation, type: 'highlight', color: tools['highlight'].color }, true);
@@ -84,7 +90,7 @@ function FindPopup({ params, onChange, onFindNext, onFindPrevious, onAddAnnotati
 				onChange({ ...params, popupOpen: false, active: false, result: null });
 			}
 		}
-		else if (code === 'Ctrl-Alt-Digit2') {
+		else if (code === 'Ctrl-Alt-Digit2'&& !queryChanged) {
 			preventInputRef.current = true;
 			if (params.result?.annotation) {
 				onAddAnnotation({ ...params.result.annotation, type: 'underline', color: tools['underline'].color }, true);


### PR DESCRIPTION
Hi! This PR fixes the bug described here: https://github.com/zotero/zotero/issues/4972

The bug: when the search field contains one character, the "enter" button does not trigger a new search. Moreover, if the field value was obtained as a result of letter deletion (for example, the first search was 'tr', the second search was: 't'), the search is performed on the old value ('tr').

The bug is expalined by the debouncing behaviour, and how the seach keyword is passed to the search engine. The solution is: whenever a key combination is triggered, we must distinguish two situations
1. **the seach field changed**, so we must start a fresh search for the case of `enter` or `shift+enter`
2. **the seach field did not change**, so we can call the `findNext` or `findPrevious` 

Visual testing: 
1. before 

https://github.com/user-attachments/assets/8d8aed9d-7002-4c98-b18e-9f06eca5364e

2. after


https://github.com/user-attachments/assets/f8710861-4868-4806-ab39-d753fb705e39

