### PR TITLE
Avoid doubled line breaks due to `<br><div>...</div>` in editor

### DIFF
--- a/src/common/components/common/editor.js
+++ b/src/common/components/common/editor.js
@@ -69,17 +69,6 @@ function walkUnformat(parent) {
 			}
 		}
 
-		// Unwrap <div><br></div> and some <div>...</div> to avoid doubled line breaks in innerText
-		if (child.nodeName === 'DIV'
-			&& (child.firstChild && child.firstChild.nodeName === 'BR'
-				|| child.nodeName === 'DIV' && child.nextSibling && child.nextSibling.nodeName === 'DIV'
-				&& child.nextSibling.firstChild && child.nextSibling.firstChild.nodeName === 'BR')
-		) {
-			let firstNode = child.firstChild;
-			child.replaceWith(...child.childNodes);
-			child = firstNode;
-		}
-
 		walkUnformat(child);
 		child = child.nextSibling;
 	}
@@ -278,6 +267,14 @@ let Content = React.forwardRef((props, ref) => {
 				walkFormat(innerRef.current);
 			}
 		}
+	});
+
+	useEffect(() => {
+		// By default, Firefox's implementation of contentEditable produces
+		// <br><div>...</div> sequences for single line breaks, but its
+		// implementation of innerText then renders that as two line breaks.
+		// Tell Firefox to always use <br>. Other browsers will ignore this.
+		document.execCommand('defaultParagraphSeparator', false, 'br');
 	});
 
 	useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Fixes zotero/zotero#5591