### PR TITLE
Expose sidebar view value

### DIFF
--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -54,6 +54,7 @@ class Reader {
 		this._onOpenContextMenu = options.onOpenContextMenu;
 		this._onToggleSidebar = options.onToggleSidebar;
 		this._onChangeSidebarWidth = options.onChangeSidebarWidth;
+		this._onChangeSidebarView = options.onChangeSidebarView;
 		this._onChangeViewState = options.onChangeViewState;
 		this._onOpenLink = options.onOpenLink;
 		this._onCopyImage = options.onCopyImage;
@@ -175,7 +176,7 @@ class Reader {
 			pageLabels: [],
 			sidebarOpen: options.sidebarOpen !== undefined ? options.sidebarOpen : true,
 			sidebarWidth: options.sidebarWidth !== undefined ? options.sidebarWidth : 240,
-			sidebarView: 'annotations',
+			sidebarView: options.sidebarView !== undefined ? options.sidebarView : 'annotations',
 			contextPaneOpen: options.contextPaneOpen !== undefined ? options.contextPaneOpen : false,
 			bottomPlaceholderHeight: options.bottomPlaceholderHeight || null,
 			toolbarPlaceholderWidth: options.toolbarPlaceholderWidth || 0,
@@ -302,7 +303,10 @@ class Reader {
 						onToggleAppearancePopup={this.toggleAppearancePopup.bind(this)}
 						onToggleFind={this.toggleFindPopup.bind(this)}
 						onChangeFilter={this.setFilter.bind(this)}
-						onChangeSidebarView={this.setSidebarView.bind(this)}
+						onChangeSidebarView={(view) => {
+							this.setSidebarView(view);
+							this._onChangeSidebarView(view);
+						}}
 						onToggleSidebar={(open) => {
 							this.toggleSidebar(open);
 							this._onToggleSidebar(open);

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -34,6 +34,7 @@ async function createReader() {
 		annotations: demo.annotations,
 		primaryViewState: demo.state,
 		sidebarWidth: 240,
+		sidebarView: 'annotations', //thumbnails, outline
 		bottomPlaceholderHeight: null,
 		toolbarPlaceholderWidth: 0,
 		authorName: 'John',
@@ -69,6 +70,9 @@ async function createReader() {
 		},
 		onChangeSidebarWidth(width) {
 			console.log('Sidebar width changed', width);
+		},
+		onChangeSidebarView(view) {
+			console.log('Sidebar view changed', view);
 		},
 		onSetDataTransferAnnotations(dataTransfer, annotations, fromText) {
 			console.log('Set formatted dataTransfer annotations', dataTransfer, annotations, fromText);

--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -3630,12 +3630,8 @@ class PDFView {
 			return;
 		}
 		if (sidebarView === 'outline' && !this._outline) {
+			await this.initializedPromise;
 			await this._iframeWindow.PDFViewerApplication.initializedPromise;
-			// TODO: Properly wait for pdfDocument initialization
-			if (!this._iframeWindow.PDFViewerApplication.pdfDocument) {
-				setTimeout(() => this.setSidebarView('outline'), 1000);
-				return;
-			}
 			let outline = await this._iframeWindow.PDFViewerApplication.pdfDocument.getOutline2();
 			this._onSetOutline(outline);
 		}


### PR DESCRIPTION
This PR exposes `sidebarView` to be configurable and adds a callback for when it changes. It allows implementation of zotero/zotero#5489.

@mrtcode I’ve removed a piece of logic that re-triggers the outline view in the sidebar and replaced it with awaiting an initialization promise a bit earlier (changes in [pdf-view.js](https://github.com/zotero/reader/compare/master...tnajdek:reader:master#diff-dc9c9811fb40595555f1941adf74c9768c3cbce44a6b784946e04cc67138b859)). Otherwise, the reader would crash if the outline was configured as the initial view. Can you see any problems with this approach?