### PR TITLE
Refactor core Read Aloud logic into new `ReadAloudManager`

### DIFF
--- a/src/common/components/reader-ui.js
+++ b/src/common/components/reader-ui.js
@@ -158,8 +158,6 @@ const ReaderUI = React.forwardRef((props, ref) => {
 						onChangeTool={props.onChangeTool}
 						onOpenColorContextMenu={props.onOpenColorContextMenu}
 						onToggleAppearancePopup={props.onToggleAppearancePopup}
-						onChangeReadAloudState={props.onChangeReadAloudState}
-						onSetReadAloudVoice={props.onSetReadAloudVoice}
 						onToggleReadAloud={props.onToggleReadAloud}
 						onToggleFind={props.onToggleFind}
 						onToggleContextPane={props.onToggleContextPane}
@@ -265,13 +263,9 @@ const ReaderUI = React.forwardRef((props, ref) => {
 				{props.enableReadAloud && state.readAloudState.popupOpen && state.readAloudState.lang && (
 					!state.readAloudFirstRunPopup
 						? <ReadAloudPopup
-							params={state.readAloudState}
-							persistedVoices={state.readAloudVoices}
-							remoteInterface={props.readAloudRemoteInterface}
+							manager={props.readAloudManager}
 							title={state.title}
 							loggedIn={state.loggedIn}
-							onChange={props.onChangeReadAloudState}
-							onSetVoice={props.onSetReadAloudVoice}
 							onOpenVoicePreferences={props.onOpenVoicePreferences}
 							onPurchaseCredits={props.onPurchaseReadAloudCredits}
 							onLogIn={props.onLogIn}

--- a/src/common/components/utility-popup/read-aloud-popup.js
+++ b/src/common/components/utility-popup/read-aloud-popup.js
@@ -13,387 +13,111 @@ import IconClock from '../../../../res/icons/12/clock.svg';
 import { Localized, useLocalization } from '@fluent/react';
 import CustomSelect from '../common/custom-select';
 import LanguageRegionSelect from '../../read-aloud/components/language-region-select';
-import { RemoteReadAloudProvider } from '../../read-aloud/remote/provider';
-import { BrowserReadAloudProvider } from '../../read-aloud/browser/provider';
-import { getBaseLanguage, getPreferredRegion, resolveLanguage } from '../../read-aloud/lang';
-import { getSupportedLanguages, getVoicesForLanguage, getVoiceRegion } from '../../read-aloud/voice';
+import { getBaseLanguage } from '../../read-aloud/lang';
 import { useSamplePlayback } from '../../read-aloud/components/use-sample-playback';
 import { useMediaControls } from '../../read-aloud/components/use-media-controls';
 import { buildVoiceOptions } from '../../read-aloud/voice-options';
 import { formatTimeRemaining } from '../../lib/format-time-remaining';
 
-const URGENT_THRESHOLD_MINUTES = 3;
-
 function ReadAloudPopup(props) {
-	let { params, persistedVoices, remoteInterface, title, loggedIn, onChange, onSetVoice, onOpenVoicePreferences, onPurchaseCredits, onLogIn, onAddAnnotation, onLockPosition } = props;
-	let controller = params.controller;
+	let { manager, title, loggedIn, onOpenVoicePreferences, onPurchaseCredits, onLogIn, onAddAnnotation, onLockPosition } = props;
 
 	let [showOptions, setShowOptions] = useState(false);
-	let [selectedTier, setSelectedTier] = useState(null);
-	let [allVoices, setAllVoices] = useState([]);
-	let [isBuffering, setBuffering] = useState(false);
 	let [showSpinner, setShowSpinner] = useState(false);
-	let [minutesRemaining, setMinutesRemaining] = useState(null);
-	let [isQuotaExceeded, setQuotaExceeded] = useState(false);
-	let [isQuotaLow, setQuotaLow] = useState(false);
-	let [hasStandardMinutesRemaining, setHasStandardMinutesRemaining] = useState(false);
-	let [error, setError] = useState(null);
-	let [devMode, setDevMode] = useState(false);
 
 	let { playSample, stopSample } = useSamplePlayback();
 
-	let tiers = useMemo(
-		() => new Set(allVoices.map(v => v.tier)),
-		[allVoices]
-	);
-
-	let voices = useMemo(
-		() => allVoices.filter((voice) => {
-			return selectedTier === null || voice.tier === selectedTier;
-		}),
-		[allVoices, selectedTier]
-	);
-
-	let languages = useMemo(
-		() => getSupportedLanguages(voices),
-		[voices]
-	);
-
-	let currentVoiceRegion = useMemo(() => {
-		let voice = allVoices.find(v => v.id === params.voice);
-		return voice ? getVoiceRegion(voice) : null;
-	}, [allVoices, params.voice]);
-
-	let voicesForLanguage = useMemo(
-		() => {
-			let region = currentVoiceRegion ?? params.region;
-			let lang = region ? `${params.lang}-${region}` : params.lang;
-			return getVoicesForLanguage(voices, lang);
-		},
-		[voices, params.lang, params.region, currentVoiceRegion]
-	);
-
-	let { voice: persistedVoice, region: persistedRegion, speed: persistedSpeed, tierVoices: persistedTierVoices } = useMemo(() => {
-		let lang = resolveLanguage(params.lang, [...persistedVoices.keys()]);
-		if (!lang) return {};
-		return persistedVoices.get(lang) ?? {};
-	}, [params.lang, persistedVoices]);
-
-	// Memoize the best fallback voice ID to avoid non-primitive useEffect deps
-	let fallbackVoiceID = useMemo(() => {
-		if (!voicesForLanguage.length) {
-			console.log('Voice fallback: no voices for language, returning null');
-			return null;
-		}
-		let targetTier = selectedTier;
-		if (!targetTier && persistedTierVoices) {
-			let persistedTier = Object.keys(persistedTierVoices).pop();
-			if (persistedTier) {
-				targetTier = persistedTier;
-			}
-		}
-		console.log(`Voice fallback: targetTier = ${targetTier}, selectedTier = ${selectedTier}, lang = ${params.lang}, ${voicesForLanguage.length} voices for language`);
-		// Stay within targetTier unless it has no voices for this language
-		let pool = targetTier
-			? voicesForLanguage.filter(v => v.tier === targetTier)
-			: voicesForLanguage;
-		if (!pool.length) {
-			console.log(`Voice fallback: no voices in tier ${targetTier}, falling back to all ${voicesForLanguage.length} voices`);
-			pool = voicesForLanguage;
-		}
-		let isAvailable = id => id && pool.some(v => v.id === id);
-		// Skip persisted voice when user explicitly selected a different region
-		let regionChanged = params.region && persistedRegion && params.region !== persistedRegion;
-
-		// 1. Tier-specific voice for this language
-		if (!regionChanged && isAvailable(persistedTierVoices?.[targetTier])) {
-			console.log(`Voice fallback: using tier-specific voice ${persistedTierVoices[targetTier]}`);
-			return persistedTierVoices[targetTier];
-		}
-		// 2. Last-used voice for this language
-		if (!regionChanged && isAvailable(persistedVoice)) {
-			console.log(`Voice fallback: using last-used voice ${persistedVoice}`);
-			return persistedVoice;
-		}
-		// 3. First voice matching the selected, persisted, or preferred region
-		let region = params.region || persistedRegion || getPreferredRegion(params.lang);
-		if (region) {
-			let regionMatch = pool.find(v => getVoiceRegion(v) === region);
-			if (regionMatch) {
-				console.log(`Voice fallback: using region match ${regionMatch.id} (region: ${region})`);
-				return regionMatch.id;
-			}
-		}
-		console.log(`Voice fallback: no match found, returning null (persistedVoice = ${persistedVoice}, region = ${region}, pool = ${pool.length})`);
-		return null;
-	}, [params.lang, params.region, persistedRegion, persistedTierVoices, persistedVoice, selectedTier, voicesForLanguage]);
-
-	// Fall back to local when selected tier when it becomes unavailable
-	useEffect(() => {
-		if (selectedTier !== null && !tiers.has(selectedTier) && tiers.has('local')) {
-			setSelectedTier('local');
-		}
-	}, [selectedTier, tiers, onChange]);
-
-	let paramsRef = useRef(params);
-	let pausedRef = useRef(params.paused);
-	let pendingSetVoiceRef = useRef(false);
-	useEffect(() => {
-		paramsRef.current = params;
-		pausedRef.current = params.paused;
-	}, [params]);
+	let allVoices = manager.allVoices;
+	let active = manager.active;
+	let selectedTier = manager.selectedTier;
+	let selectedVoiceID = manager.selectedVoiceID;
+	let tiers = manager.tiers;
+	let languages = manager.languages;
+	let voicesForLanguage = manager.voicesForLanguage;
+	let currentVoiceRegion = manager.currentVoiceRegion;
+	let lang = manager.lang;
+	let paused = manager.paused;
+	let speed = manager.speed;
+	let buffering = manager.buffering;
+	let segments = manager.segments;
+	let error = manager.error;
+	let minutesRemaining = manager.minutesRemaining;
+	let isQuotaExceeded = manager.isQuotaExceeded;
+	let isQuotaLow = manager.isQuotaLow;
+	let hasStandardMinutesRemaining = manager.hasStandardMinutesRemaining;
+	let devMode = manager.devMode;
 
 	useEffect(() => {
-		let showBufferingSpinner = !params.segments || isBuffering;
+		let showBufferingSpinner = !segments || buffering;
 		if (!showBufferingSpinner) {
 			setShowSpinner(false);
 			return undefined;
 		}
 		let timeout = setTimeout(() => setShowSpinner(showBufferingSpinner), 250);
 		return () => clearTimeout(timeout);
-	}, [isBuffering, params.segments]);
+	}, [buffering, segments]);
 
 	useEffect(() => {
-		let voice = allVoices.find(v => v.id === params.voice);
-		if (!voice || !voicesForLanguage.some(v => v.id === params.voice)) {
-			onChange({ controller: undefined });
-			return undefined;
+		if (error === 'quota-exceeded' || error === 'daily-limit-exceeded' || isQuotaLow) {
+			setShowOptions(true);
 		}
-		onChange({ segmentGranularity: voice.segmentGranularity, active: true });
-		if (!params.segments) {
-			onChange({ controller: undefined });
-			return undefined;
-		}
-		let backwardStopIndex = params.backwardStopIndex;
-		// Use ref to access activeSegment so we don't rerun when it changes
-		if (params.segments && paramsRef.current.activeSegment && params.segments.includes(paramsRef.current.activeSegment)) {
-			backwardStopIndex = params.segments.indexOf(paramsRef.current.activeSegment);
-		}
-		let controller = voice.getController(params.segments, backwardStopIndex, params.forwardStopIndex);
-		onChange({ controller });
-
-		controller.addEventListener('BufferingChange', () => {
-			setBuffering(controller.buffering);
-		});
-		controller.addEventListener('ActiveSegmentChanging', (event) => {
-			onChange({ activeSegment: event.segment, lastSkipGranularity: controller.lastSkipGranularity });
-		});
-		controller.addEventListener('ActiveSegmentChange', (event) => {
-			onChange({ activeSegment: event.segment, lastSkipGranularity: controller.lastSkipGranularity });
-		});
-		controller.addEventListener('Complete', () => {
-			onChange({
-				paused: true,
-				activeSegment: null
-			});
-		});
-		controller.addEventListener('Error', () => {
-			if (controller.error === 'quota-exceeded' || controller.error === 'daily-limit-exceeded') {
-				setShowOptions(true);
-			}
-			onChange({ paused: true });
-			setError(controller.error);
-		});
-		controller.addEventListener('ErrorCleared', () => {
-			setError(null);
-		});
-
-		setSelectedTier(voice.tier);
-		setError(null);
-
-		return () => {
-			controller.destroy();
-		};
-	}, [allVoices, onChange, params.backwardStopIndex, params.forwardStopIndex, params.lang, params.segments, params.voice, voicesForLanguage]);
+	}, [error, isQuotaLow]);
 
 	useEffect(() => {
-		if (!controller) return;
-		// Guard against redundant sets -- the setter restarts audio playback,
-		// and this effect also re-runs on controller change with unchanged speed.
-		if (controller.speed !== params.speed) {
-			controller.speed = params.speed;
-		}
-	}, [controller, params.speed]);
-
-	// Reset language when it becomes unavailable
-	useEffect(() => {
-		let baseLang = getBaseLanguage(params.lang);
-		if (languages.length && !languages.some(l => getBaseLanguage(l) === baseLang)) {
-			let resolved = resolveLanguage(params.lang, languages) || languages[0];
-			onChange({ lang: resolved, region: null, voice: null });
-		}
-	}, [languages, onChange, params.lang]);
-
-	useEffect(() => {
-		if (!controller) {
-			return;
-		}
-		controller.paused = params.paused;
-	}, [controller, params.paused]);
-
-	useEffect(() => {
-		if (!params.paused) {
+		if (!paused) {
 			stopSample();
 		}
-	}, [params.paused, stopSample]);
+	}, [paused, stopSample]);
 
 	useMediaControls({
-		active: !!controller,
+		active,
 		title,
-		paused: params.paused,
-		speed: params.speed,
+		paused,
+		speed,
 		useSilentAudio: true,
 		onSetPaused: (paused) => {
 			if (!paused) {
 				onLockPosition();
 			}
-			onChange({ paused });
+			if (paused) {
+				manager.pause();
+			}
+			else {
+				manager.play();
+			}
 		},
 		onSkipBack: () => {
-			controller?.skipBack();
+			manager.skipBack();
 			onLockPosition();
 		},
 		onSkipAhead: () => {
-			controller?.skipAhead();
+			manager.skipAhead();
 			onLockPosition();
 		},
 	});
 
-	useEffect(() => {
-		if (!controller) {
-			setMinutesRemaining(null);
-			setQuotaExceeded(false);
-			setQuotaLow(false);
-			setHasStandardMinutesRemaining(false);
-			return undefined;
-		}
-
-		let updateRemaining = () => {
-			setMinutesRemaining(controller.minutesRemaining);
-			setHasStandardMinutesRemaining(controller.hasStandardMinutesRemaining);
-
-			let isQuotaExceeded = controller.error === 'quota-exceeded';
-			let isQuotaLow = isQuotaExceeded
-				|| (controller.minutesRemaining !== null
-					&& controller.minutesRemaining < URGENT_THRESHOLD_MINUTES);
-			setQuotaExceeded(isQuotaExceeded);
-			setQuotaLow(isQuotaLow);
-			if (isQuotaExceeded) {
-				onChange({ paused: true });
-			}
-			if (isQuotaLow) {
-				setShowOptions(true);
-			}
-		};
-		updateRemaining();
-
-		let interval = setInterval(updateRemaining, 10_000);
-		return () => clearInterval(interval);
-	}, [controller, params.paused, onChange]);
-
-	useEffect(() => {
-		if (!controller) {
-			return undefined;
-		}
-		let interval = setInterval(() => controller.refreshCreditsRemaining(), 60_000);
-		return () => clearInterval(interval);
-	}, [controller]);
-
-	useEffect(() => {
-		let cancelled = false;
-
-		let fetchVoicesAndSet = async () => {
-			let remoteProvider = new RemoteReadAloudProvider(remoteInterface);
-			let browserProvider = new BrowserReadAloudProvider();
-
-			let handleError = (e) => {
-				console.error(e);
-				return [];
-			};
-			let [remoteVoices, browserVoices] = await Promise.all([
-				loggedIn ? remoteProvider.getVoices().catch(handleError) : [],
-				browserProvider.getVoices().catch(handleError),
-			]);
-			if (!cancelled) {
-				setAllVoices([...remoteVoices, ...browserVoices]);
-				setDevMode(remoteProvider.devMode);
-			}
-		};
-		fetchVoicesAndSet();
-
-		return () => {
-			cancelled = true;
-		};
-	}, [loggedIn, remoteInterface]);
-
-	useEffect(() => {
-		if (params.voice && voicesForLanguage.some(v => v.id === params.voice)) {
-			return;
-		}
-
-		if (!voicesForLanguage.length) {
-			console.log('Voice selection: no voices for language, skipping');
-			return;
-		}
-
-		let speed = persistedSpeed || 1;
-		let voiceID = fallbackVoiceID;
-		if (!voiceID) {
-			console.log(`Voice selection: no fallback voice, using first voice ${voicesForLanguage[0].id}`);
-			voiceID = voicesForLanguage[0].id;
-			speed = params.speed;
-		}
-		else {
-			console.log(`Voice selection: using fallback voice ${voiceID} (persistedSpeed = ${persistedSpeed})`);
-		}
-
-		console.log(`Voice selection: setting voice = ${voiceID}, speed = ${speed}, active = ${voiceID !== params.voice ? false : params.active} (was voice: ${params.voice})`);
-		onChange({
-			voice: voiceID,
-			speed,
-			active: voiceID !== params.voice ? false : params.active,
-		});
-	}, [allVoices, fallbackVoiceID, onChange, params.active, params.lang, params.speed, params.voice, persistedSpeed, selectedTier, voicesForLanguage]);
-
-	// Persist voice after a manual language change, once the voice selection
-	// effect has resolved the new voice.
-	useEffect(() => {
-		if (pendingSetVoiceRef.current && params.voice) {
-			pendingSetVoiceRef.current = false;
-			let voice = allVoices.find(v => v.id === params.voice);
-			let tier = selectedTier || voice?.tier;
-			let region = voice ? getVoiceRegion(voice) : null;
-			onSetVoice({ lang: getBaseLanguage(params.lang), region, voice: params.voice, speed: params.speed, tier });
-		}
-	}, [allVoices, onSetVoice, params.lang, params.speed, params.voice, selectedTier]);
-
 	function handleTierChange(value) {
-		setSelectedTier(value);
-		let restoredVoice = persistedTierVoices?.[value] ?? null;
-		pendingSetVoiceRef.current = true;
-		onChange({ voice: restoredVoice });
+		manager.selectTier(value);
 	}
 
 	function handleUserVoiceSelect(voiceID) {
-		onChange({ voice: voiceID });
-		let voice = allVoices.find(v => v.id === voiceID);
-		let tier = selectedTier || voice?.tier;
-		let region = voice ? getVoiceRegion(voice) : null;
-		onSetVoice({ lang: getBaseLanguage(params.lang), region, voice: voiceID, speed: params.speed, tier });
+		manager.selectVoice(voiceID);
+		if (paused) {
+			let voice = allVoices.find(v => v.id === voiceID);
+			if (voice) {
+				playSample(voice);
+			}
+		}
 	}
 
 	function handleLangChange(fullLang) {
 		let base = getBaseLanguage(fullLang);
 		let region = fullLang.includes('-') ? fullLang.substring(base.length + 1) : null;
-		pendingSetVoiceRef.current = true;
-		onChange({ lang: base, region, voice: null });
+		manager.setLanguage(base, { region, persist: true });
 	}
 
 	async function handleResetCredits() {
-		if (controller) {
-			await controller.resetCredits();
-			setMinutesRemaining(controller.minutesRemaining);
-		}
+		await manager.resetCredits();
 	}
 
 	return (
@@ -402,22 +126,33 @@ function ReadAloudPopup(props) {
 				showOptions={showOptions}
 				onToggleOptions={() => setShowOptions(!showOptions)}
 				showSpinner={showSpinner}
-				paused={params.paused}
-				onPlayPause={() => onChange({ paused: !params.paused })}
-				controller={controller}
-				onAddAnnotation={onAddAnnotation}
+				paused={paused}
+				onPlayPause={() => manager.togglePaused()}
+				onSkipBack={(granularity, accelerate) => {
+					manager.skipBack(granularity, accelerate);
+					onLockPosition();
+				}}
+				onSkipAhead={(granularity, accelerate) => {
+					manager.skipAhead(granularity, accelerate);
+					onLockPosition();
+				}}
+				onAddAnnotation={() => {
+					let segment = manager.getSegmentToAnnotate();
+					if (segment) {
+						onAddAnnotation(segment);
+					}
+				}}
 				onLockPosition={onLockPosition}
 			/>
 			{showOptions && <>
 				<SpeedSlider
-					speed={params.speed}
-					paused={params.paused}
-					onChange={onChange}
-					onSetVoice={onSetVoice}
-					lang={getBaseLanguage(params.lang)}
-					region={currentVoiceRegion}
-					voice={params.voice}
-					tier={selectedTier}
+					speed={speed}
+					paused={paused}
+					isLocal={selectedTier === 'local'}
+					onSetSpeed={(s) => manager.setSpeed(s)}
+					onPersistSpeed={() => manager.setSpeed(manager.speed, true)}
+					onPause={() => manager.pause()}
+					onPlay={() => manager.play()}
 				/>
 				<TierSelect
 					loggedIn={loggedIn}
@@ -428,14 +163,13 @@ function ReadAloudPopup(props) {
 				/>
 				<LanguageRegionSelect
 					languages={languages}
-					lang={currentVoiceRegion ? `${params.lang}-${currentVoiceRegion}` : params.lang}
+					lang={currentVoiceRegion ? `${lang}-${currentVoiceRegion}` : lang}
 					onLangChange={handleLangChange}
 					tabIndex="-1"
 				/>
 				<VoiceSelect
-					params={params}
+					voiceID={selectedVoiceID}
 					voices={voicesForLanguage}
-					playSample={playSample}
 					onChange={handleUserVoiceSelect}
 					onOpenVoicePreferences={selectedTier === 'local' ? onOpenVoicePreferences : null}
 				/>
@@ -450,12 +184,7 @@ function ReadAloudPopup(props) {
 				/>
 			</>}
 			{error !== null && error !== 'quota-exceeded' && (
-				<ErrorMessage error={error} onRetry={controller?.retry
-					? () => {
-						onChange({ paused: false });
-						controller.retry();
-					}
-					: null}/>
+				<ErrorMessage error={error} onRetry={() => manager.retry()}/>
 			)}
 		</UtilityPopup>
 	);
@@ -464,14 +193,7 @@ function ReadAloudPopup(props) {
 function PlaybackControls(props) {
 	const { l10n } = useLocalization();
 
-	let { showOptions, onToggleOptions, showSpinner, paused, onPlayPause, controller, onAddAnnotation, onLockPosition } = props;
-
-	function handleAddAnnotation() {
-		let segment = controller?.getSegmentToAnnotate();
-		if (segment) {
-			onAddAnnotation(segment);
-		}
-	}
+	let { showOptions, onToggleOptions, showSpinner, paused, onPlayPause, onSkipBack, onSkipAhead, onAddAnnotation, onLockPosition } = props;
 
 	return (
 		<div className="row buttons" data-tabstop={1}>
@@ -489,8 +211,7 @@ function PlaybackControls(props) {
 					title={l10n.getString('reader-read-aloud-skip-back')}
 					tabIndex="-1"
 					onClick={(event) => {
-						controller?.skipBack(event.altKey ? 'sentence' : 'paragraph', event.shiftKey);
-						onLockPosition();
+						onSkipBack(event.altKey ? 'sentence' : 'paragraph', event.shiftKey);
 					}}
 				><IconSkipBack/></button>
 				{showSpinner
@@ -515,8 +236,7 @@ function PlaybackControls(props) {
 					title={l10n.getString('reader-read-aloud-skip-ahead')}
 					tabIndex="-1"
 					onClick={(event) => {
-						controller?.skipAhead(event.altKey ? 'sentence' : 'paragraph', event.shiftKey);
-						onLockPosition();
+						onSkipAhead(event.altKey ? 'sentence' : 'paragraph', event.shiftKey);
 					}}
 				><IconSkipAhead/></button>
 			</div>
@@ -525,7 +245,7 @@ function PlaybackControls(props) {
 					className="toolbar-button"
 					title={l10n.getString('reader-read-aloud-add-annotation', { key1: 'H', key2: 'U' })}
 					tabIndex="-1"
-					onClick={handleAddAnnotation}
+					onClick={onAddAnnotation}
 				><IconAnnotate/></button>
 			</div>
 		</div>
@@ -535,23 +255,24 @@ function PlaybackControls(props) {
 function SpeedSlider(props) {
 	const { l10n } = useLocalization();
 
-	let { speed, paused, onChange, onSetVoice, lang, region, voice, tier } = props;
+	let { speed, paused, isLocal, onSetSpeed, onPersistSpeed, onPause, onPlay } = props;
 	let [speedWhileDragging, setSpeedWhileDragging] = useState(null);
 	let draggingRef = useRef(false);
 	let wasPlayingRef = useRef(false);
-	let isLocal = tier === 'local';
 
 	function handleSpeedChange(event) {
 		let newSpeed = parseFloat(event.target.value);
 		if (!draggingRef.current) {
-			onChange({ speed: newSpeed });
-			onSetVoice({ lang, region, voice, speed: newSpeed, tier });
+			onSetSpeed(newSpeed);
+			onPersistSpeed();
 		}
 		else if (isLocal) {
+			// Local voices pause during drag, so just update the display value
 			setSpeedWhileDragging(newSpeed);
 		}
 		else {
-			onChange({ speed: newSpeed });
+			// Remote voices apply speed changes live during drag
+			onSetSpeed(newSpeed);
 		}
 	}
 
@@ -561,7 +282,7 @@ function SpeedSlider(props) {
 			setSpeedWhileDragging(speed);
 			wasPlayingRef.current = !paused;
 			if (!paused) {
-				onChange({ paused: true });
+				onPause();
 			}
 		}
 	}
@@ -574,21 +295,16 @@ function SpeedSlider(props) {
 		if (isLocal) {
 			let newSpeed = speedWhileDragging;
 			setSpeedWhileDragging(null);
-			let changes = {};
 			if (newSpeed !== null && newSpeed !== speed) {
-				changes.speed = newSpeed;
+				onSetSpeed(newSpeed);
 			}
 			if (wasPlayingRef.current) {
-				changes.paused = false;
+				onPlay();
 			}
-			if (Object.keys(changes).length) {
-				onChange(changes);
-			}
-			onSetVoice({ lang, region, voice, speed: newSpeed ?? speed, tier });
 		}
-		else {
-			onSetVoice({ lang, region, voice, speed, tier });
-		}
+		// Persist whatever speed the manager currently has.
+		// Don't re-set it, because that could restart the current segment.
+		onPersistSpeed();
 	}
 
 	return (
@@ -654,7 +370,7 @@ function TierSelect(props) {
 function VoiceSelect(props) {
 	const { l10n } = useLocalization();
 
-	let { params, voices, playSample, onChange, onOpenVoicePreferences } = props;
+	let { voiceID, voices, onChange, onOpenVoicePreferences } = props;
 
 	function handleVoiceChange(optionValue) {
 		if (optionValue === 'more-voices') {
@@ -662,19 +378,13 @@ function VoiceSelect(props) {
 			return;
 		}
 		onChange(optionValue);
-		if (params.paused) {
-			let voice = voices.find(v => v.id === optionValue);
-			if (voice) {
-				playSample(voice);
-			}
-		}
 	}
 
 	if (!voices.length) {
 		return null;
 	}
 
-	let { options, selectedValue } = buildVoiceOptions(voices, params.voice);
+	let { options, selectedValue } = buildVoiceOptions(voices, voiceID);
 	if (onOpenVoicePreferences) {
 		options.push({ value: 'more-voices', label: l10n.getString('reader-read-aloud-more-voices') });
 	}

--- a/src/common/keyboard-manager.js
+++ b/src/common/keyboard-manager.js
@@ -50,7 +50,7 @@ export class KeyboardManager {
 		let code = getCodeCombination(event);
 
 		let sidebarAnnotationFocused = document.activeElement.classList.contains('annotation');
-		let readAloudActive = this._reader._state.readAloudState.active;
+		let readAloudActive = this._reader._readAloudManager.active;
 
 		if (this._reader._state.readAloudState.annotationPopup) {
 			if (['Escape', 'Enter'].includes(key)) {
@@ -293,7 +293,7 @@ export class KeyboardManager {
 		else if (code === 'KeyR' || code === 'KeyL') {
 			event.preventDefault();
 			event.stopPropagation();
-			if (this._reader._state.readAloudState.active && !this._reader.getSelectionPosition()) {
+			if (this._reader._readAloudManager.active && !this._reader.getSelectionPosition()) {
 				this._reader.toggleReadAloudPopup(false);
 			}
 			else {
@@ -401,7 +401,7 @@ export class KeyboardManager {
 					this._reader.setTool({ color: ANNOTATION_COLORS[idx][1] });
 				}
 			}
-			else if (this._reader._type === 'pdf' && key === 'h' && !this._reader._state.readAloudState.active) {
+			else if (this._reader._type === 'pdf' && key === 'h' && !this._reader._readAloudManager.active) {
 				this._reader.toggleHandTool();
 			}
 			else if (this._reader._type === 'pdf' && key === 's') {
@@ -416,31 +416,31 @@ export class KeyboardManager {
 				else if (key === `Alt-${arrowPrev}` || key === `Alt-Shift-${arrowPrev}`) {
 					event.preventDefault();
 					event.stopPropagation();
-					this._reader._state.readAloudState.controller?.skipBack('sentence', event.shiftKey);
+					this._reader._readAloudManager.skipBack('sentence', event.shiftKey);
 					this._reader._lockPositionToReadAloud();
 				}
 				else if (key === `Alt-${arrowNext}` || key === `Alt-Shift-${arrowNext}`) {
 					event.preventDefault();
 					event.stopPropagation();
-					this._reader._state.readAloudState.controller?.skipAhead('sentence', event.shiftKey);
+					this._reader._readAloudManager.skipAhead('sentence', event.shiftKey);
 					this._reader._lockPositionToReadAloud();
 				}
 				else if (key === arrowPrev || key === `Shift-${arrowPrev}`) {
 					event.preventDefault();
 					event.stopPropagation();
-					this._reader._state.readAloudState.controller?.skipBack('paragraph', event.shiftKey);
+					this._reader._readAloudManager.skipBack('paragraph', event.shiftKey);
 					this._reader._lockPositionToReadAloud();
 				}
 				else if (key === arrowNext || key === `Shift-${arrowNext}`) {
 					event.preventDefault();
 					event.stopPropagation();
-					this._reader._state.readAloudState.controller?.skipAhead('paragraph', event.shiftKey);
+					this._reader._readAloudManager.skipAhead('paragraph', event.shiftKey);
 					this._reader._lockPositionToReadAloud();
 				}
 				else if (key === 'h' || key === 'H' || key === 'u' || key === 'U') {
 					event.preventDefault();
 					event.stopPropagation();
-					let segment = this._reader._state.readAloudState.controller?.getSegmentToAnnotate();
+					let segment = this._reader._readAloudManager.getSegmentToAnnotate();
 					if (segment) {
 						this._reader.addAnnotationFromReadAloudSegment(
 							segment,

--- a/src/common/read-aloud/manager.ts
+++ b/src/common/read-aloud/manager.ts
@@ -1,0 +1,689 @@
+import { Position, ReadAloudGranularity, ReadAloudSegment } from '../types';
+import { ErrorState, ReadAloudController, ReadAloudEvent } from './controller';
+import { getSupportedLanguages, getVoiceRegion, getVoicesForLanguage, ReadAloudVoice, Tier } from './voice';
+import { RemoteReadAloudProvider } from './remote/provider';
+import { BrowserReadAloudProvider } from './browser/provider';
+import { RemoteInterface } from './remote';
+import { getBaseLanguage, getPreferredRegion, resolveLanguage } from './lang';
+
+const URGENT_THRESHOLD_MINUTES = 3;
+
+type PersistedVoiceData = {
+	voice?: string;
+	region?: string;
+	speed?: number;
+	tierVoices?: Record<string, string>;
+};
+
+export type ReadAloudManagerOptions = {
+	remoteInterface: RemoteInterface | null;
+	onStateChange: () => void;
+	onRequestSegments: () => void;
+	onComputeRepositionIndex: (position: Position) => number | null;
+	onSetVoice: (data: { lang: string, region: string | null, voice: string, speed: number, tier: string | null }) => void;
+};
+
+/**
+ * Owns the Read Aloud engine lifecycle: controller creation/destruction,
+ * voice resolution, credit polling, and playback state.
+ * Does not know about React or the DOM.
+ */
+export class ReadAloudManager {
+	private _options: ReadAloudManagerOptions;
+
+	// Engine
+	private _controller: ReadAloudController | null = null;
+
+	private _voice: ReadAloudVoice | null = null;
+
+	// Segments
+	private _segments: ReadAloudSegment[] | null = null;
+
+	private _backwardStopIndex: number | null = null;
+
+	private _forwardStopIndex: number | null = null;
+
+	/**
+	 * Transient target position for initial segment computation.
+	 * Set before activation, consumed by _composeReadAloudStateSnapshot,
+	 * then cleared.
+	 */
+	private _targetPosition: Position | null = null;
+
+	// Playback state
+	private _active = false;
+
+	private _paused = true;
+
+	private _speed = 1;
+
+	private _activeSegment: ReadAloudSegment | null = null;
+
+	private _lastSkipGranularity: 'sentence' | 'paragraph' | null = null;
+
+	private _buffering = false;
+
+	private _error: ErrorState | null = null;
+
+	// Voice catalog
+	private _allVoices: ReadAloudVoice[] = [];
+
+	private _selectedTier: Tier | null = null;
+
+	private _lang: string | null = null;
+
+	private _region: string | null = null;
+
+	private _voiceID: string | null = null;
+
+	private _segmentGranularity: ReadAloudGranularity | null = null;
+
+	private _devMode = false;
+
+	private _persistedVoices: PersistedVoiceData = {};
+
+	private _pendingSetVoice = false;
+
+	// Periodic server refresh for credit balance
+	private _creditRefreshInterval: ReturnType<typeof setInterval> | null = null;
+
+	constructor(options: ReadAloudManagerOptions) {
+		this._options = options;
+	}
+
+	get active(): boolean {
+		return this._active;
+	}
+
+	get paused(): boolean {
+		return this._paused;
+	}
+
+	get speed(): number {
+		return this._speed;
+	}
+
+	get activeSegment(): ReadAloudSegment | null {
+		return this._activeSegment;
+	}
+
+	get lastSkipGranularity(): 'sentence' | 'paragraph' | null {
+		return this._lastSkipGranularity;
+	}
+
+	get buffering(): boolean {
+		return this._buffering;
+	}
+
+	get error(): ErrorState | null {
+		return this._error;
+	}
+
+	get segments(): ReadAloudSegment[] | null {
+		return this._segments;
+	}
+
+	get minutesRemaining(): number | null {
+		return this._controller?.minutesRemaining ?? null;
+	}
+
+	get isQuotaExceeded(): boolean {
+		return this._controller?.error === 'quota-exceeded';
+	}
+
+	get isQuotaLow(): boolean {
+		return this.isQuotaExceeded
+			|| (this.minutesRemaining !== null && this.minutesRemaining < URGENT_THRESHOLD_MINUTES);
+	}
+
+	get hasStandardMinutesRemaining(): boolean {
+		return this._controller?.hasStandardMinutesRemaining ?? false;
+	}
+
+	get segmentGranularity(): ReadAloudGranularity | null {
+		return this._segmentGranularity;
+	}
+
+	get lang(): string | null {
+		return this._lang;
+	}
+
+	get region(): string | null {
+		return this._region;
+	}
+
+	get selectedVoiceID(): string | null {
+		return this._voiceID;
+	}
+
+	get selectedTier(): Tier | null {
+		return this._selectedTier;
+	}
+
+	get allVoices(): ReadAloudVoice[] {
+		return this._allVoices;
+	}
+
+	get devMode(): boolean {
+		return this._devMode;
+	}
+
+	get voices(): ReadAloudVoice[] {
+		return this._allVoices.filter(
+			v => this._selectedTier === null || v.tier === this._selectedTier
+		);
+	}
+
+	get languages(): string[] {
+		return getSupportedLanguages(this.voices);
+	}
+
+	get currentVoiceRegion(): string | null {
+		let voice = this._allVoices.find(v => v.id === this._voiceID);
+		return voice ? getVoiceRegion(voice) : null;
+	}
+
+	get voicesForLanguage(): ReadAloudVoice[] {
+		let region = this.currentVoiceRegion ?? this._region;
+		let lang = region ? `${this._lang}-${region}` : this._lang;
+		return getVoicesForLanguage(this.voices, lang ?? '');
+	}
+
+	get tiers(): Set<Tier> {
+		return new Set(this._allVoices.map(v => v.tier));
+	}
+
+	get targetPosition(): Position | null {
+		return this._targetPosition;
+	}
+
+	setTargetPosition(position: Position | null): void {
+		this._targetPosition = position;
+	}
+
+	consumeTargetPosition(): Position | undefined {
+		let pos = this._targetPosition ?? undefined;
+		this._targetPosition = null;
+		return pos;
+	}
+
+	async loadVoices(loadRemote: boolean): Promise<void> {
+		let remoteProvider = this._options.remoteInterface
+			? new RemoteReadAloudProvider(this._options.remoteInterface)
+			: null;
+		let browserProvider = new BrowserReadAloudProvider();
+
+		let handleError = (e: unknown) => {
+			console.error(e);
+			return [] as ReadAloudVoice[];
+		};
+		let [remoteVoices, browserVoices] = await Promise.all([
+			loadRemote && remoteProvider ? remoteProvider.getVoices().catch(handleError) : [],
+			browserProvider.getVoices().catch(handleError),
+		]);
+		this._allVoices = [...remoteVoices, ...browserVoices];
+		this._devMode = remoteProvider?.devMode ?? false;
+
+		this._resolveVoice();
+		this._stateChanged();
+	}
+
+	/**
+	 * Set the language. If the language actually changed, clears the
+	 * current voice and re-resolves.
+	 */
+	setLanguage(lang: string, { region = null, persist = false }: { region?: string | null, persist?: boolean } = {}): void {
+		let base = getBaseLanguage(lang);
+		if (base === this._lang && region === this._region) {
+			return;
+		}
+		this._lang = base;
+		this._region = region;
+		this._voiceID = null;
+		if (persist) {
+			this._pendingSetVoice = true;
+		}
+		if (this._allVoices.length) {
+			this._resolveVoice();
+		}
+		this._stateChanged();
+	}
+
+	selectVoice(voiceID: string): void {
+		this._voiceID = voiceID;
+		this._applyVoice();
+		this._persistCurrentVoice();
+		this._stateChanged();
+	}
+
+	selectTier(tier: Tier): void {
+		this._selectedTier = tier;
+		// Preserve the current region so the fallback logic tries to
+		// match it in the new tier
+		this._region = this.currentVoiceRegion ?? this._region;
+		// Restore persisted voice for this tier, if any
+		this._voiceID = this._persistedVoices.tierVoices?.[tier] ?? null;
+		this._pendingSetVoice = true;
+		this._resolveVoice();
+		this._stateChanged();
+	}
+
+	applyPersistedVoices(persisted: PersistedVoiceData): void {
+		this._persistedVoices = persisted;
+		// Clear current voice and tier so _resolveVoice re-evaluates
+		// from scratch using the new persisted preferences
+		this._voiceID = null;
+		this._selectedTier = null;
+		this._resolveVoice();
+		this._stateChanged();
+	}
+
+	setSpeed(speed: number, persist = false): void {
+		this._speed = speed;
+		if (this._controller && this._controller.speed !== speed) {
+			this._controller.speed = speed;
+		}
+		if (persist) {
+			this._persistCurrentVoice();
+		}
+		this._stateChanged();
+	}
+
+	/**
+	 * Persist the current voice preferences via the onSetVoice callback.
+	 */
+	private _persistCurrentVoice(): void {
+		if (!this._voiceID) return;
+		let voice = this._allVoices.find(v => v.id === this._voiceID);
+		let tier = this._selectedTier || voice?.tier || null;
+		let region = voice ? getVoiceRegion(voice) : null;
+		this._options.onSetVoice({
+			lang: getBaseLanguage(this._lang ?? ''),
+			region,
+			voice: this._voiceID,
+			speed: this._speed,
+			tier,
+		});
+	}
+
+	/**
+	 * Resolve the best voice for the current language/tier/persisted preferences.
+	 * Mirrors the fallback logic formerly in ReadAloudPopup's fallbackVoiceID useMemo
+	 * and voice selection useEffect.
+	 */
+	private _resolveVoice(): void {
+		// If no language yet, wait for the view to report one
+		if (!this._lang) {
+			return;
+		}
+
+		// Cache tier-filtered voices to avoid redundant getter evaluations
+		let tierVoices = this.voices;
+		let languages = getSupportedLanguages(tierVoices);
+
+		// Compute candidate voices from the base language, not from
+		// currentVoiceRegion - voice could've been set before lang changed
+		let lang = this._region ? `${this._lang}-${this._region}` : this._lang;
+		let voicesForLang = getVoicesForLanguage(tierVoices, lang);
+
+		// Reset language if it's no longer available
+		let baseLang = getBaseLanguage(this._lang);
+		if (languages.length && !languages.some(l => getBaseLanguage(l) === baseLang)) {
+			let resolved = resolveLanguage(this._lang, languages) || languages[0];
+			this._lang = getBaseLanguage(resolved);
+			this._region = null;
+			this._voiceID = null;
+			lang = this._lang;
+			voicesForLang = getVoicesForLanguage(tierVoices, lang);
+		}
+
+		// Fall back to local when selected tier becomes unavailable
+		let tiers = this.tiers;
+		if (this._selectedTier !== null && !tiers.has(this._selectedTier) && tiers.has('local')) {
+			this._selectedTier = 'local';
+		}
+
+		// If current voice is still valid, keep it
+		if (this._voiceID && voicesForLang.some(v => v.id === this._voiceID)) {
+			this._applyVoice();
+			return;
+		}
+
+		if (!voicesForLang.length) {
+			return;
+		}
+
+		// Find fallback voice
+		let voiceID = this._findFallbackVoice(voicesForLang);
+		if (!voiceID) {
+			voiceID = voicesForLang[0].id;
+		}
+
+		let wasVoiceID = this._voiceID;
+		this._voiceID = voiceID;
+
+		if (voiceID !== wasVoiceID) {
+			this._applyVoice();
+		}
+
+		// Handle pending set voice (after language/tier change)
+		if (this._pendingSetVoice && this._voiceID) {
+			this._pendingSetVoice = false;
+			this._persistCurrentVoice();
+		}
+	}
+
+	private _findFallbackVoice(voicesForLang: ReadAloudVoice[]): string | null {
+		let { voice: persistedVoice, region: persistedRegion, tierVoices: persistedTierVoices }
+			= this._persistedVoices;
+
+		let targetTier = this._selectedTier;
+		if (!targetTier && persistedTierVoices) {
+			let persistedTier = Object.keys(persistedTierVoices).pop();
+			if (persistedTier) {
+				targetTier = persistedTier as Tier;
+			}
+		}
+
+		// Stay within targetTier unless it has no voices for this language
+		let pool = targetTier
+			? voicesForLang.filter(v => v.tier === targetTier)
+			: voicesForLang;
+		if (!pool.length) {
+			pool = voicesForLang;
+		}
+		let isAvailable = (id: string | undefined) => id && pool.some(v => v.id === id);
+
+		// Skip persisted voice when user explicitly selected a different region
+		let regionChanged = this._region && persistedRegion && this._region !== persistedRegion;
+
+		// 1. Tier-specific voice for this language
+		if (!regionChanged && isAvailable(persistedTierVoices?.[targetTier as string])) {
+			return persistedTierVoices![targetTier as string];
+		}
+		// 2. Last-used voice for this language
+		if (!regionChanged && isAvailable(persistedVoice)) {
+			return persistedVoice!;
+		}
+		// 3. First voice matching the selected, persisted, or preferred region
+		let region = this._region || persistedRegion || getPreferredRegion(this._lang ?? '');
+		if (region) {
+			let regionMatch = pool.find(v => getVoiceRegion(v) === region);
+			if (regionMatch) {
+				return regionMatch.id;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Apply the current _voiceID: find the voice object, update segment granularity,
+	 * and recreate the controller if segments exist.
+	 */
+	private _applyVoice(): void {
+		let voice = this._allVoices.find(v => v.id === this._voiceID);
+		if (!voice || !this.voicesForLanguage.some(v => v.id === this._voiceID)) {
+			this._voice = null;
+			this._destroyController();
+			return;
+		}
+
+		// Always update the voice fields so activate() can use them
+		let granularityChanged = voice.segmentGranularity !== this._segmentGranularity;
+		this._voice = voice;
+		this._segmentGranularity = voice.segmentGranularity;
+		this._selectedTier = voice.tier;
+
+		// Only request segments / create controller when active.
+		// When not active, the caller (activate/play) will do this
+		// after setting _active.
+		if (!this._active) {
+			return;
+		}
+
+		if (!this._segments || granularityChanged) {
+			// Request (re)computation of segments from the view
+			this._segments = null;
+			this._options.onRequestSegments();
+		}
+		else {
+			// Same granularity, segments exist: recreate controller with new voice
+			this._createController();
+		}
+	}
+
+	clearSegments(): void {
+		this._segments = null;
+		this._backwardStopIndex = null;
+		this._forwardStopIndex = null;
+		this._activeSegment = null;
+		this._destroyController();
+	}
+
+	setSegments(
+		segments: ReadAloudSegment[],
+		backwardStopIndex: number | null,
+		forwardStopIndex: number | null,
+	): void {
+		this._segments = segments;
+		this._backwardStopIndex = backwardStopIndex;
+		this._forwardStopIndex = forwardStopIndex;
+		this._createController();
+		this._stateChanged();
+	}
+
+	activate(): void {
+		if (!this._voice) return;
+		this._active = true;
+		this._paused = false;
+		this._segmentGranularity = this._voice.segmentGranularity;
+		this._options.onRequestSegments();
+		this._stateChanged();
+	}
+
+	play(): void {
+		if (!this._active) {
+			this.activate();
+			return;
+		}
+		this._paused = false;
+		if (this._controller) {
+			this._controller.paused = false;
+		}
+		this._stateChanged();
+	}
+
+	pause(): void {
+		this._paused = true;
+		if (this._controller) {
+			this._controller.paused = true;
+		}
+		this._stateChanged();
+	}
+
+	togglePaused(): void {
+		if (this._paused) {
+			this.play();
+		}
+		else {
+			this.pause();
+		}
+	}
+
+	skipBack(granularity: 'sentence' | 'paragraph' = 'paragraph', accelerate = false): void {
+		this._controller?.skipBack(granularity, accelerate);
+	}
+
+	skipAhead(granularity: 'sentence' | 'paragraph' = 'paragraph', accelerate = false): void {
+		this._controller?.skipAhead(granularity, accelerate);
+	}
+
+	getSegmentToAnnotate(): ReadAloudSegment | null {
+		return this._controller?.getSegmentToAnnotate() ?? null;
+	}
+
+	retry(): void {
+		if (this._controller?.retry) {
+			this._paused = false;
+			this._controller.retry();
+			this._stateChanged();
+		}
+	}
+
+	/**
+	 * Jump to a position within existing segments.
+	 * No-op if not active or segments haven't been computed yet.
+	 */
+	jumpTo(position: Position): void {
+		if (!this._segments || !this._active) {
+			return;
+		}
+		let index = this._options.onComputeRepositionIndex(position);
+		if (index !== null) {
+			this.repositionTo(index);
+		}
+	}
+
+	/**
+	 * Reposition the controller to a new segment index without full
+	 * segment recomputation.
+	 */
+	repositionTo(backwardStopIndex: number): void {
+		this._backwardStopIndex = backwardStopIndex;
+		this._forwardStopIndex = null;
+		this._paused = false;
+		this._activeSegment = null;
+		this._createController();
+		this._stateChanged();
+	}
+
+	async refreshCreditsRemaining(): Promise<void> {
+		if (this._controller) {
+			await this._controller.refreshCreditsRemaining();
+			this._stateChanged();
+		}
+	}
+
+	async resetCredits(): Promise<void> {
+		if (this._controller) {
+			await this._controller.resetCredits();
+			this._stateChanged();
+		}
+	}
+
+	private _startCreditRefresh(): void {
+		this._stopCreditRefresh();
+		this._creditRefreshInterval = setInterval(() => {
+			this.refreshCreditsRemaining();
+		}, 60_000);
+	}
+
+	private _stopCreditRefresh(): void {
+		if (this._creditRefreshInterval !== null) {
+			clearInterval(this._creditRefreshInterval);
+			this._creditRefreshInterval = null;
+		}
+	}
+
+	private _createController(): void {
+		this._destroyController();
+
+		if (!this._voice || !this._segments) {
+			return;
+		}
+
+		// If the active segment is still in the segment list, start from it
+		let backwardStopIndex = this._backwardStopIndex;
+		if (this._segments && this._activeSegment && this._segments.includes(this._activeSegment)) {
+			backwardStopIndex = this._segments.indexOf(this._activeSegment);
+		}
+
+		let controller = this._voice.getController(
+			this._segments,
+			backwardStopIndex,
+			this._forwardStopIndex,
+		);
+
+		this._controller = controller;
+		this._error = null;
+
+		// Sync speed
+		if (controller.speed !== this._speed) {
+			controller.speed = this._speed;
+		}
+
+		// Wire up event listeners
+		controller.addEventListener('BufferingChange', () => {
+			this._buffering = controller.buffering;
+			this._stateChanged();
+		});
+		controller.addEventListener('ActiveSegmentChanging', (event: Event) => {
+			this._activeSegment = (event as ReadAloudEvent).segment;
+			this._lastSkipGranularity = controller.lastSkipGranularity;
+			this._stateChanged();
+		});
+		controller.addEventListener('ActiveSegmentChange', (event: Event) => {
+			this._activeSegment = (event as ReadAloudEvent).segment;
+			this._lastSkipGranularity = controller.lastSkipGranularity;
+			this._stateChanged();
+		});
+		controller.addEventListener('Complete', () => {
+			this._paused = true;
+			this._activeSegment = null;
+			this._stateChanged();
+		});
+		controller.addEventListener('Error', () => {
+			this._paused = true;
+			this._error = controller.error;
+			this._stateChanged();
+		});
+		controller.addEventListener('ErrorCleared', () => {
+			this._error = null;
+			this._stateChanged();
+		});
+
+		// Start credit polling
+		this._startCreditRefresh();
+
+		// Sync paused state
+		controller.paused = this._paused;
+	}
+
+	private _destroyController(): void {
+		if (this._controller) {
+			this._controller.destroy();
+			this._controller = null;
+			this._buffering = false;
+		}
+		this._stopCreditRefresh();
+	}
+
+	deactivate(): void {
+		this._active = false;
+		this._paused = true;
+		this._segments = null;
+		this._backwardStopIndex = null;
+		this._forwardStopIndex = null;
+		this._activeSegment = null;
+		this._lastSkipGranularity = null;
+		this._error = null;
+		this._destroyController();
+		this._stateChanged();
+	}
+
+	private _stateChangePending = false;
+
+	private _stateChanged(): void {
+		if (!this._stateChangePending) {
+			this._stateChangePending = true;
+			queueMicrotask(() => {
+				this._stateChangePending = false;
+				this._options.onStateChange();
+			});
+		}
+	}
+
+	destroy(): void {
+		this._destroyController();
+	}
+}

--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -29,6 +29,8 @@ import { debounce } from './lib/debounce';
 import { flushSync } from 'react-dom';
 import { addFTL, getLocalizedString } from '../fluent';
 import { getVoicePreferencesURL } from './lib/read-aloud-links';
+import { resolveLanguage } from './read-aloud/lang';
+import { ReadAloudManager } from './read-aloud/manager';
 
 // Compute style values for usage in views (CSS variables aren't sufficient for that)
 // Font family is necessary for text annotations
@@ -100,6 +102,8 @@ class Reader {
 
 		this._enableAnnotationDeletionFromComment = false;
 		this._annotationSelectionTriggeredFromView = false;
+		this._lastReadAloudPaused = true;
+		this._lastReadAloudActiveSegment = null;
 
 		// Stores the default or current values for each annotation type
 		this._tools = {
@@ -155,6 +159,23 @@ class Reader {
 		this._enableReadAloud = options.enableReadAloud || false;
 		this._readAloudRemoteInterface = options.readAloudRemoteInterface || null;
 
+		this._readAloudManager = new ReadAloudManager({
+			remoteInterface: this._readAloudRemoteInterface,
+			onStateChange: () => this._onReadAloudEngineStateChanged(),
+			onRequestSegments: () => {
+				// Push composed view state to views. The view will see
+				// segments == null along with segmentGranularity, compute segments,
+				// and feed them back via onSetReadAloudState(), which calls setSegments().
+				this._pushReadAloudToViews();
+			},
+			onComputeRepositionIndex: (position) => {
+				let segments = this._readAloudManager.segments;
+				if (!segments || !this._primaryView) return null;
+				return this._primaryView.computeReadAloudRepositionIndex(position, segments);
+			},
+			onSetVoice: data => this._setReadAloudVoice(data),
+		});
+
 		this._state = {
 			splitType: null,
 			splitSize: '50%',
@@ -206,14 +227,6 @@ class Reader {
 			contextMenu: null,
 			readAloudState: {
 				popupOpen: false,
-				active: false,
-				paused: false,
-				segments: null,
-				backwardStopIndex: null,
-				forwardStopIndex: null,
-				activeSegment: null,
-				speed: 1,
-				voice: null,
 				annotationPopup: null,
 				segmentAnnotations: new Map(),
 				savedPosition: options.primaryViewState?.lastReadAloudPosition ?? null,
@@ -335,7 +348,7 @@ class Reader {
 						onChangeTool={this.setTool.bind(this)}
 						onToggleAppearancePopup={this.toggleAppearancePopup.bind(this)}
 						enableReadAloud={this._enableReadAloud}
-						onChangeReadAloudState={this._handleReadAloudStateChange.bind(this)}
+						readAloudManager={this._readAloudManager}
 						readAloudRemoteInterface={this._readAloudRemoteInterface}
 						onSetReadAloudVoice={this._setReadAloudVoice.bind(this)}
 						onOpenVoicePreferences={this.openVoicePreferences.bind(this)}
@@ -550,34 +563,8 @@ class Reader {
 		}
 
 		if (this._state.readAloudState !== previousState.readAloudState) {
-			// If the view has a new Read Aloud target, reset our state
-			if (!this._state.readAloudState.paused && previousState.readAloudState.paused
-					&& this._primaryView?.hasReadAloudTarget) {
-				Object.assign(this._state.readAloudState, this._getReadAloudSegmentResetState());
-			}
-
-			// Update savedPosition when the active segment changes.
-			// Convert to a format usable as targetPosition and serializable
-			// for the synced setting.
-			let { activeSegment } = this._state.readAloudState;
-			if (activeSegment && activeSegment !== previousState.readAloudState.activeSegment) {
-				let savedPosition = activeSegment.position;
-				if (this._primaryView) {
-					savedPosition = this._primaryView.getSerializableReadAloudPosition(savedPosition);
-				}
-				this._state.readAloudState.savedPosition = savedPosition;
-			}
-
-			this._primaryView?.setReadAloudState(this._state.readAloudState);
-			this._secondaryView?.setReadAloudState(this._state.readAloudState);
-
-			// Tell Zotero about the two main status flags
-			let { active, paused } = this._state.readAloudState;
-			let status = { active, paused };
-			if (!basicDeepEqual(status, this._lastReadAloudStatus)) {
-				this._lastReadAloudStatus = status;
-				this._onSetReadAloudStatus?.(status);
-			}
+			// Push composed view state (from manager + UI state) to views
+			this._pushReadAloudToViews();
 
 			// If the first-run popup should be shown and we have an external handler,
 			// call it instead of rendering the inline popup
@@ -937,29 +924,110 @@ class Reader {
 		}
 	}
 
-	_handleReadAloudStateChange(state) {
+	/**
+	 * Update UI-only Read Aloud state (popupOpen, annotationPopup, etc.)
+	 * and push the composed view state to views.
+	 */
+	_updateReadAloudUIState(state) {
 		// Ignore late changes due to event handlers after popup has closed
 		if (!this._state.readAloudState.popupOpen && !state.popupOpen) {
 			return;
 		}
-		// When Read Aloud becomes active with no explicit target, resume from
-		// the saved position, which may have been persisted from a previous session
-		if (state.active && !this._state.readAloudState.active
-				&& !state.targetPosition
-				&& this._state.readAloudState.savedPosition) {
-			state = { ...state, targetPosition: this._state.readAloudState.savedPosition };
-		}
 		this._updateState({ readAloudState: { ...this._state.readAloudState, ...state } });
 	}
 
-	_getReadAloudSegmentResetState() {
+	/**
+	 * Called when the manager's engine state changes.
+	 * Pushes composed view state to views, updates savedPosition,
+	 * reports status to Zotero, and triggers a React re-render.
+	 */
+	_onReadAloudEngineStateChanged() {
+		let manager = this._readAloudManager;
+
+		// Auto-activate once a voice is resolved and the popup is open
+		// (but not during first-run, where the user picks a tier first)
+		if (this._state.readAloudState.popupOpen
+				&& !this._state.readAloudFirstRunPopup
+				&& manager.selectedVoiceID
+				&& !manager.active) {
+			manager.activate();
+			return;
+		}
+
+		// If the view has a selection target and we're unpausing, reset segments
+		// so they'll be recomputed from the selection
+		if (!manager.paused && this._lastReadAloudPaused
+				&& this._primaryView?.hasReadAloudTarget) {
+			manager.clearSegments();
+		}
+		this._lastReadAloudPaused = manager.paused;
+
+		// Update savedPosition when the active segment changes
+		let activeSegment = manager.activeSegment;
+		if (activeSegment && activeSegment !== this._lastReadAloudActiveSegment) {
+			let savedPosition = activeSegment.position;
+			if (this._primaryView) {
+				savedPosition = this._primaryView.getSerializableReadAloudPosition(savedPosition);
+			}
+			this._state.readAloudState.savedPosition = savedPosition;
+		}
+		this._lastReadAloudActiveSegment = activeSegment;
+
+		// Report active/paused status to Zotero
+		let status = { active: manager.active, paused: manager.paused };
+		if (!basicDeepEqual(status, this._lastReadAloudStatus)) {
+			this._lastReadAloudStatus = status;
+			this._onSetReadAloudStatus?.(status);
+		}
+
+		// Trigger React re-render so the popup reads fresh manager state.
+		// Spread creates a new reference without changing content.
+		this._updateState({
+			readAloudState: { ...this._state.readAloudState },
+		});
+	}
+
+	/**
+	 * Compose a ReadAloudStateSnapshot from manager + UI state, and push to views.
+	 */
+	_pushReadAloudToViews() {
+		let stateSnapshot = this._composeReadAloudStateSnapshot();
+		this._primaryView?.setReadAloudState(stateSnapshot);
+		this._secondaryView?.setReadAloudState(stateSnapshot);
+	}
+
+	_composeReadAloudStateSnapshot() {
+		let manager = this._readAloudManager;
 		return {
-			segments: null,
+			popupOpen: this._state.readAloudState.popupOpen,
+			active: manager.active,
+			paused: manager.paused,
+			segmentGranularity: manager.segmentGranularity,
+			segments: manager.segments,
+			activeSegment: manager.activeSegment,
 			backwardStopIndex: null,
 			forwardStopIndex: null,
-			activeSegment: null,
-			segmentAnnotations: new Map(),
+			targetPosition: manager.consumeTargetPosition(),
+			lastSkipGranularity: manager.lastSkipGranularity,
+			annotationPopup: this._state.readAloudState.annotationPopup,
+			lang: manager.lang || this._state.readAloudState.lang,
 		};
+	}
+
+	_syncPersistedVoicesToManager() {
+		let manager = this._readAloudManager;
+		let lang = manager.lang;
+		if (!lang) return;
+		let resolvedLang = resolveLanguage(lang, [...this._state.readAloudVoices.keys()]);
+		let persisted = resolvedLang ? this._state.readAloudVoices.get(resolvedLang) : {};
+		manager.applyPersistedVoices(persisted || {});
+		if (persisted?.speed) {
+			manager.setSpeed(persisted.speed);
+		}
+	}
+
+	_resetReadAloudSegmentState() {
+		this._state.readAloudState.segmentAnnotations = new Map();
 	}
 
 	_lockPositionToReadAloud() {
@@ -984,20 +1052,21 @@ class Reader {
 			this._updateState({
 				readAloudFirstRunPopup: !this._state.readAloudVoices.size,
 			});
-			this._handleReadAloudStateChange({
+			this._updateReadAloudUIState({
 				popupOpen: true,
 			});
+			this._readAloudManager.loadVoices(this._state.loggedIn);
+			this._syncPersistedVoicesToManager();
 		}
 		else {
+			this._readAloudManager.deactivate();
+			this._resetReadAloudSegmentState();
 			this._updateState({
 				readAloudFirstRunPopup: false,
 			});
-			this._handleReadAloudStateChange({
+			this._updateReadAloudUIState({
 				popupOpen: false,
-				active: false,
-				paused: false,
 				annotationPopup: null,
-				...this._getReadAloudSegmentResetState(),
 			});
 		}
 	}
@@ -1006,16 +1075,21 @@ class Reader {
 		if (!this._enableReadAloud) {
 			return;
 		}
-		if (!this._state.readAloudState.active) {
+		if (!this._readAloudManager.active) {
 			return;
 		}
 		if (paused === undefined) {
-			paused = !this._state.readAloudState.paused;
+			paused = !this._readAloudManager.paused;
 		}
 		if (!paused) {
 			this._lockPositionToReadAloud();
 		}
-		this._handleReadAloudStateChange({ paused });
+		if (paused) {
+			this._readAloudManager.pause();
+		}
+		else {
+			this._readAloudManager.play();
+		}
 	}
 
 	startReadAloudAtPosition(position = null) {
@@ -1023,23 +1097,28 @@ class Reader {
 			return;
 		}
 		position ||= this.getSelectionPosition();
-		// If already active with segments, just reposition without reinitializing
-		if (this._state.readAloudState.active && this._state.readAloudState.segments) {
-			this._handleReadAloudStateChange({
-				paused: false,
-				targetPosition: position,
-				activeSegment: null,
-				forwardStopIndex: null,
-			});
+		// If already active with segments, jump
+		if (this._readAloudManager.active && this._readAloudManager.segments) {
+			this._lockPositionToReadAloud();
+			if (position) {
+				this._readAloudManager.jumpTo(position);
+			}
+			else {
+				this._readAloudManager.play();
+			}
 		}
 		else {
-			this._handleReadAloudStateChange({
-				popupOpen: true,
-				active: true,
-				paused: false,
-				targetPosition: position,
-				...this._getReadAloudSegmentResetState(),
-			});
+			// Not yet active: Open popup and start with target position.
+			// Store targetPosition on the manager so it's included when
+			// the view state is composed for initial segment computation.
+			this._readAloudManager.setTargetPosition(position);
+			if (this._state.readAloudState.savedPosition && !position) {
+				this._readAloudManager.setTargetPosition(this._state.readAloudState.savedPosition);
+			}
+			this._resetReadAloudSegmentState();
+			this._updateReadAloudUIState({ popupOpen: true });
+			this._readAloudManager.loadVoices(this._state.loggedIn);
+			this._syncPersistedVoicesToManager();
 		}
 	}
 
@@ -1063,6 +1142,17 @@ class Reader {
 				lang,
 			},
 		});
+		// If the manager isn't active yet (first-run popup flow), sync
+		// persisted voices so it can resolve, then activate.
+		// When already active, the manager already has the right voice --
+		// don't re-sync (which would nuke and recreate the controller).
+		if (!this._readAloudManager.active) {
+			this._readAloudManager.setLanguage(lang);
+			this._syncPersistedVoicesToManager();
+			if (this._readAloudManager.selectedVoiceID) {
+				this._readAloudManager.activate();
+			}
+		}
 	}
 
 	setReadAloudVoices(readAloudVoices) {
@@ -1070,7 +1160,8 @@ class Reader {
 	}
 
 	addAnnotationFromReadAloudSegment(segment, type) {
-		let { annotationPopup: popup, segments, segmentAnnotations } = this._state.readAloudState;
+		let { annotationPopup: popup, segmentAnnotations } = this._state.readAloudState;
+		let segments = this._readAloudManager.segments;
 		// If the annotation popup is already open, just change the type if specified
 		if (popup) {
 			if (type) {
@@ -1094,7 +1185,7 @@ class Reader {
 					endSegmentIndex = Math.max(endSegmentIndex, idx);
 				}
 			}
-			this._handleReadAloudStateChange({
+			this._updateReadAloudUIState({
 				annotationPopup: {
 					annotation: existingAnnotation,
 					baseSegmentIndex: segmentIndex,
@@ -1127,7 +1218,7 @@ class Reader {
 		);
 		if (annotation && segments && segmentIndex >= 0) {
 			segmentAnnotations.set(segmentIndex, annotation.id);
-			this._handleReadAloudStateChange({
+			this._updateReadAloudUIState({
 				annotationPopup: {
 					annotation,
 					baseSegmentIndex: segmentIndex,
@@ -1174,7 +1265,7 @@ class Reader {
 			for (let i = newStartIndex; i <= newEndIndex; i++) {
 				segmentAnnotations.set(i, newAnnotation.id);
 			}
-			this._handleReadAloudStateChange({
+			this._updateReadAloudUIState({
 				annotationPopup: {
 					annotation: newAnnotation,
 					baseSegmentIndex: newBaseIndex,
@@ -1239,7 +1330,7 @@ class Reader {
 	}
 
 	dismissReadAloudAnnotationPopup() {
-		this._handleReadAloudStateChange({ annotationPopup: null });
+		this._updateReadAloudUIState({ annotationPopup: null });
 	}
 
 	deleteReadAloudAnnotation() {
@@ -1254,7 +1345,7 @@ class Reader {
 			segmentAnnotations.delete(i);
 		}
 		this._annotationManager.deleteAnnotations([popup.annotation.id]);
-		this._handleReadAloudStateChange({ annotationPopup: null });
+		this._updateReadAloudUIState({ annotationPopup: null });
 	}
 
 	setReadAloudAnnotationColor(color) {
@@ -1266,7 +1357,7 @@ class Reader {
 			id: popup.annotation.id,
 			color,
 		}]);
-		this._handleReadAloudStateChange({
+		this._updateReadAloudUIState({
 			annotationPopup: {
 				...popup,
 				annotation: this._annotationManager._getAnnotationByID(popup.annotation.id),
@@ -1283,7 +1374,7 @@ class Reader {
 			id: popup.annotation.id,
 			type,
 		}]);
-		this._handleReadAloudStateChange({
+		this._updateReadAloudUIState({
 			annotationPopup: {
 				...popup,
 				annotation: this._annotationManager._getAnnotationByID(popup.annotation.id),
@@ -1447,7 +1538,31 @@ class Reader {
 				console.warn(`View tried to set Read Aloud lang to tag containing region: ${params.lang}. Return only the bare language.`);
 				params.lang = params.lang.replace(/-.*$/, '');
 			}
-			this._updateState({ readAloudState: params });
+			// Route view outputs to the appropriate owner:
+
+			// targetPosition: manager (imperative jump)
+			if (params.targetPosition && this._readAloudManager.active && this._readAloudManager.segments) {
+				this._readAloudManager.jumpTo(params.targetPosition);
+			}
+			// segments: manager (new segments or segment clear)
+			if ('segments' in params) {
+				if (params.segments && params.segments !== this._readAloudManager.segments) {
+					this._readAloudManager.setSegments(
+						params.segments,
+						params.backwardStopIndex,
+						params.forwardStopIndex,
+					);
+				}
+				else if (params.segments === null) {
+					this._readAloudManager.clearSegments();
+				}
+			}
+			// lang: manager and readAloudState (for rendering gate)
+			if (params.lang && !this._readAloudManager.lang) {
+				this._readAloudManager.setLanguage(params.lang);
+				this._updateReadAloudUIState({ lang: params.lang });
+				this._syncPersistedVoicesToManager();
+			}
 		};
 
 		let onSelectAnnotations = (ids, triggeringEvent) => {
@@ -1524,7 +1639,7 @@ class Reader {
 			lightTheme: this._state.lightTheme,
 			darkTheme: this._state.darkTheme,
 			colorScheme: this._state.colorScheme,
-			readAloudState: this._state.readAloudState,
+			readAloudState: this._composeReadAloudStateSnapshot(),
 			findState: this._state[primary ? 'primaryViewFindState' : 'secondaryViewFindState'],
 			viewState: this._state[primary ? 'primaryViewState' : 'secondaryViewState'],
 			location,

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,7 +1,6 @@
 import { Selector } from "../dom/common/lib/selector";
 import { ReflowableAppearance } from "../dom/common/lib/appearance";
 import { PersistentRange } from '../dom/common/lib/range';
-import { ReadAloudController } from './read-aloud/controller';
 
 export type ToolType =
 	| 'highlight'
@@ -187,23 +186,47 @@ export type ReadAloudAnnotationPopup = {
 	segments: ReadAloudSegment[];
 };
 
+/**
+ * UI-only state stored on the React state tree.
+ * Engine state (playback, segments, and voice) lives in ReadAloudManager.
+ */
 export type ReadAloudState = {
+	popupOpen: boolean;
+	lang?: string;
+	annotationPopup: ReadAloudAnnotationPopup | null;
+	segmentAnnotations: Map<number, string>;
+	savedPosition?: Position | null;
+};
+
+/**
+ * Composed state pushed to views for display (spotlights and scrolling)
+ * and segment computation.
+ */
+export type ReadAloudStateSnapshot = {
 	popupOpen: boolean;
 	active: boolean;
 	paused: boolean;
-	controller?: ReadAloudController;
-	segmentGranularity?: ReadAloudGranularity;
+	segmentGranularity: ReadAloudGranularity | null;
 	segments: ReadAloudSegment[] | null;
 	activeSegment: ReadAloudSegment | null;
 	backwardStopIndex: number | null;
 	forwardStopIndex: number | null;
 	targetPosition?: Position;
-	lang?: string;
-	speed: number;
-	voice: string | null;
+	lang: string | null;
+	lastSkipGranularity: 'sentence' | 'paragraph' | null;
 	annotationPopup: ReadAloudAnnotationPopup | null;
-	lastSkipGranularity?: 'sentence' | 'paragraph' | null;
-	savedPosition?: Position | null;
+};
+
+/**
+ * Modifications to composed state that can be returned by views
+ * using onSetReadAloudState().
+ */
+export type ReadAloudStateDelta = {
+	segments?: ReadAloudSegment[] | null;
+	backwardStopIndex?: number | null;
+	forwardStopIndex?: number | null;
+	targetPosition?: Position;
+	lang?: string | null;
 };
 
 export type ReadAloudSegment = {

--- a/src/dom/common/dom-view.tsx
+++ b/src/dom/common/dom-view.tsx
@@ -16,7 +16,6 @@ import {
 	Position,
 	ReadAloudGranularity,
 	ReadAloudSegment,
-	ReadAloudState,
 	RangeRef,
 	SelectionPopupParams,
 	Theme,
@@ -24,7 +23,7 @@ import {
 	ToolType,
 	ViewContextMenuOverlay,
 	ViewStats,
-	WADMAnnotation,
+	WADMAnnotation, ReadAloudStateDelta, ReadAloudStateSnapshot,
 } from "../../common/types";
 import PopupDelayer from "../../common/lib/popup-delayer";
 import { flushSync } from "react-dom";
@@ -1741,8 +1740,6 @@ abstract class DOMView<State extends DOMViewState, Data> {
 		blockRange.collapse(true);
 
 		this._options.onSetReadAloudState({
-			...this._readAloud.state,
-			activeSegment: null,
 			targetPosition: { range: new PersistentRange(blockRange) },
 		});
 	}
@@ -2125,7 +2122,7 @@ abstract class DOMView<State extends DOMViewState, Data> {
 		this._penExclusive = penExclusive;
 	}
 
-	setReadAloudState(state: ReadAloudState): void {
+	setReadAloudState(state: ReadAloudStateSnapshot): void {
 		if (!state.popupOpen) {
 			this._hideReadAloudJumpButton();
 		}
@@ -2145,6 +2142,10 @@ abstract class DOMView<State extends DOMViewState, Data> {
 			return this._options.onAddAnnotation(annotation);
 		}
 		return null;
+	}
+
+	computeReadAloudRepositionIndex(position: Position, segments: ReadAloudSegment[]): number | null {
+		return this._readAloud.computeRepositionIndex(position, segments);
 	}
 
 	getReadAloudRanges(granularity: ReadAloudGranularity): Range[] {
@@ -2298,7 +2299,7 @@ export type DOMViewOptions<State extends DOMViewState, Data> = {
 	onSetAnnotationPopup: (params?: AnnotationPopupParams<WADMAnnotation> | null) => void;
 	onSetOverlayPopup: (params?: OverlayPopupParams) => void;
 	onSetFindState: (state?: FindState) => void;
-	onSetReadAloudState: (state?: ReadAloudState) => void;
+	onSetReadAloudState: (state: ReadAloudStateDelta) => void;
 	onSetZoom?: (iframe: HTMLIFrameElement, zoom: number) => void;
 	onOpenViewContextMenu: (params: {
 		x: number;

--- a/src/dom/common/lib/read-aloud.ts
+++ b/src/dom/common/lib/read-aloud.ts
@@ -1,10 +1,10 @@
 import {
 	NewAnnotation,
+	Position,
 	ReadAloudGranularity,
 	ReadAloudSegment,
-	ReadAloudState,
 	RangeRef,
-	WADMAnnotation,
+	WADMAnnotation, ReadAloudStateSnapshot, ReadAloudStateDelta,
 } from "../../../common/types";
 import { exceedsSegmentMaxLength, splitTextToChunks } from "../../../common/read-aloud/segment-split";
 import { isSelector, Selector } from "./selector";
@@ -28,7 +28,7 @@ import EPUBView from '../../epub/epub-view';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ReadAloud<View extends DOMView<any, any>> {
-	state: ReadAloudState | null = null;
+	state: ReadAloudStateSnapshot | null = null;
 
 	positionLocked = true;
 
@@ -40,7 +40,7 @@ export class ReadAloud<View extends DOMView<any, any>> {
 		this._view = view;
 	}
 
-	setState(state: ReadAloudState): ReadAloudState | null {
+	setState(state: ReadAloudStateSnapshot): ReadAloudStateDelta | null {
 		let previousState = this.state;
 		this.state = state;
 
@@ -136,46 +136,12 @@ export class ReadAloud<View extends DOMView<any, any>> {
 
 		if (!state.lang && this._view.lang) {
 			return {
-				...state,
 				lang: getBaseLanguage(this._view.lang),
 			};
 		}
 
 		if (!state.active || !state.segmentGranularity) {
 			return null;
-		}
-
-		// Reposition within existing segments without reinitializing
-		if (state.segments !== null && state.targetPosition) {
-			let targetRange;
-			if (isSelector(state.targetPosition)) {
-				targetRange = this._view.toDisplayedRange(state.targetPosition as Selector);
-			}
-			else if ('range' in state.targetPosition) {
-				targetRange = state.targetPosition.range.toRange();
-			}
-			if (targetRange) {
-				let backwardStopIndex: number | null = null;
-				for (let i = 0; i < state.segments.length; i++) {
-					let segmentRange = (state.segments[i].position as RangeRef).range.toRange();
-					// Find the first segment whose end is at or past the target start
-					if (EPUBView.compareBoundaryPoints(Range.START_TO_END, segmentRange, targetRange) >= 0) {
-						backwardStopIndex = i;
-						break;
-					}
-				}
-				return {
-					...state,
-					paused: false,
-					// New array reference so the controller is always recreated,
-					// even when repositioning to the same backwardStopIndex
-					// TODO: This is not ideal; replace with a cleaner imperative approach
-					segments: [...state.segments],
-					backwardStopIndex,
-					forwardStopIndex: null,
-					targetPosition: undefined,
-				};
-			}
 		}
 
 		if (state.segments !== null && state.segmentGranularity === previousState?.segmentGranularity) {
@@ -264,13 +230,9 @@ export class ReadAloud<View extends DOMView<any, any>> {
 		let lang = state.lang || this._view.lang;
 
 		return {
-			...state,
-			paused: false,
 			segments,
-			activeSegment: null,
 			backwardStopIndex,
 			forwardStopIndex,
-			targetPosition: undefined,
 			lang,
 		};
 	}
@@ -301,6 +263,31 @@ export class ReadAloud<View extends DOMView<any, any>> {
 				...init,
 			};
 			return annotation;
+		}
+		return null;
+	}
+
+	/**
+	 * Given a target position and existing segments, find the segment index
+	 * to reposition to. Returns null if the position can't be resolved.
+	 */
+	computeRepositionIndex(position: Position, segments: ReadAloudSegment[]): number | null {
+		let targetRange;
+		if (isSelector(position)) {
+			targetRange = this._view.toDisplayedRange(position as Selector);
+		}
+		else if ('range' in position) {
+			targetRange = (position as RangeRef).range.toRange();
+		}
+		if (!targetRange) {
+			return null;
+		}
+		for (let i = 0; i < segments.length; i++) {
+			let segmentRange = (segments[i].position as RangeRef).range.toRange();
+			// Find the first segment whose end is at or past the target start
+			if (EPUBView.compareBoundaryPoints(Range.START_TO_END, segmentRange, targetRange) >= 0) {
+				return i;
+			}
 		}
 		return null;
 	}

--- a/src/dom/snapshot/snapshot-view.ts
+++ b/src/dom/snapshot/snapshot-view.ts
@@ -753,11 +753,7 @@ class SnapshotView extends DOMView<SnapshotViewState, SnapshotViewData> {
 		this._initOutline();
 		// Reset Read Aloud segments, since ranges will no longer be valid
 		if (this._readAloud.state?.active && this._readAloud.state.segments !== null) {
-			this._options.onSetReadAloudState({
-				...this._readAloud.state,
-				segments: null,
-				activeSegment: null,
-			});
+			this._options.onSetReadAloudState({ segments: null });
 		}
 		// Wait a frame due to layout not updating synchronously after <body>
 		// is replaced in Firefox

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -29,6 +29,7 @@ async function createReader() {
 	else if (type === 'snapshot') {
 		demo = snapshot;
 	}
+	let readAloudVoices = {};
 	let res = await fetch(demo.fileName);
 	let reader = new Reader({
 		type,
@@ -106,13 +107,25 @@ async function createReader() {
 		onSaveCustomThemes(customThemes) {
 			console.log('Save custom themes', customThemes);
 		},
-		onSetReadAloudVoice(options) {
-			console.log('Set read aloud voice', options);
+		onSetReadAloudVoice({ lang, region, voice, speed, tier }) {
+			console.log('Set read aloud voice', { lang, region, voice, speed, tier });
+			let existing = readAloudVoices[lang] || {};
+			let tierVoices = { ...existing.tierVoices };
+			if (tier) {
+				delete tierVoices[tier];
+				tierVoices[tier] = voice;
+			}
+			readAloudVoices = {
+				...readAloudVoices,
+				[lang]: { region, voice, speed, tierVoices },
+			};
+			reader.setReadAloudVoices(readAloudVoices);
 		},
 		onSetReadAloudStatus(status) {
 			console.log('Set read aloud status', status);
 		},
 		enableReadAloud: true,
+		readAloudVoices,
 		readAloudRemoteInterface: ZOTERO_API_KEY && {
 			async getVoices() {
 				let url = 'https://api.zotero.org/tts/voices';

--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -1100,38 +1100,12 @@ class PDFView {
 				.map(p => p.text)
 				.join('\n');
 			this._options.onSetReadAloudState({
-				...state,
 				lang: detectLang(textSample) || 'en',
 			});
 			return;
 		}
 
 		if (!state.active || !state.segmentGranularity) {
-			return;
-		}
-
-		// Reposition within existing segments without reinitializing
-		if (state.segments !== null && state.targetPosition) {
-			let backwardStopIndex = null;
-			for (let i = 0; i < state.segments.length; i++) {
-				let segment = state.segments[i];
-				if (segment.position.pageIndex === state.targetPosition.pageIndex
-					&& intersectAnnotationWithPoint(segment.position, state.targetPosition)) {
-					backwardStopIndex = i;
-					break;
-				}
-			}
-			this._options.onSetReadAloudState({
-				...state,
-				paused: false,
-				// New array reference so the controller is always recreated,
-				// even when repositioning to the same backwardStopIndex
-				// TODO: This is not ideal; replace with a cleaner imperative approach
-				segments: [...state.segments],
-				backwardStopIndex,
-				forwardStopIndex: null,
-				targetPosition: undefined,
-			});
 			return;
 		}
 
@@ -1222,13 +1196,9 @@ class PDFView {
 		}
 
 		this._options.onSetReadAloudState({
-			...state,
-			paused: false,
 			segments,
-			activeSegment: null,
 			backwardStopIndex,
 			forwardStopIndex,
-			targetPosition: undefined,
 		});
 	}
 
@@ -1293,6 +1263,17 @@ class PDFView {
 		}
 
 		return { pageIndex, rects: paragraphRects };
+	}
+
+	computeReadAloudRepositionIndex(position, segments) {
+		for (let i = 0; i < segments.length; i++) {
+			let segment = segments[i];
+			if (segment.position.pageIndex === position.pageIndex
+					&& intersectAnnotationWithPoint(segment.position, position)) {
+				return i;
+			}
+		}
+		return null;
 	}
 
 	get hasReadAloudTarget() {
@@ -1627,8 +1608,6 @@ class PDFView {
 		this._render();
 
 		this._options.onSetReadAloudState({
-			...this._readAloudState,
-			activeSegment: null,
 			targetPosition: {
 				pageIndex: paragraph.position.pageIndex,
 				rects: paragraph.position.rects,


### PR DESCRIPTION
- Fully take control of the core Read Aloud state away from `ReadAloudPopup`. The old approach - a React component owns the entire state and manages it through effects - was very fragile and made it hard to allow views to perform imperative operations like jumping between positions.
- Add `ReadAloudManager`, which encompasses all the old state with a much nicer external interface.
- Pare `reader.js`'s `_state.readAloudState` down so it only holds presentation state.
- Refactor views' `setReadAloudState()` so it works as a pure transformer over a view-specific representation of the state.
   The old system gave views the entire Read Aloud state, allowed them to modify it however they want, and then had to handle those modifications with very byzantine `useEffect()` hooks in `read-aloud-popup.js`. The new system hands the views a snapshot of the state, allows them to fill in the parts they're responsible for, then propagates those specific changes back to the manager. This makes the control flow much, much more obvious (for the jump button, for example, the previous control flow was view -> reader -> view -> reader, all driven by React hooks...) and makes the view-side code simpler.
- Persist `readAloudVoices` within the session for dev builds, so persistence can be tested working like it does in the client

I've tested this pretty thoroughly across view types and things seem to be working well, but please test more so we can be sure there aren't any regressions! The core logic is all essentially the same, but the flow has changed, so parts that were previously heavily dependent on gnarly `useEffect()` logic (like language/voice fallbacks and persistence) could have issues.

Once this is merged and being tested in beta, we can start building Read Aloud improvements on a better foundation.