### PR TITLE
onInitialized is now being sent to Android side after the WebView port was set

### DIFF
--- a/src/index.android.js
+++ b/src/index.android.js
@@ -13,6 +13,8 @@ function sendToPort(handlerName, message) {
 onmessage = function (e) {
 	if (e.data == 'initPort') {
 		port = e.ports[0];
+		// Notify when iframe and port are loaded
+        postMessage('onInitialized');
 	}
 };
 
@@ -177,6 +179,3 @@ window.enterPassword = (options) => {
 	log("Enter password");
 	window._view.enterPassword(password);
 };
-
-// Notify when iframe is loaded
-postMessage('onInitialized');


### PR DESCRIPTION
From now the flow on Android works like this:
When reader is being loaded in the Webview, Android side waits for a WebView to fire it's callback -  `onWebViewLoadPage`, which signals that reader code was loaded.
Then I execute some JS code to pass WebView Port to JS side
I wait for `onInitialized` to be returned from the JS side
Only then I execute createView against the reader.

This flow should hopefully ensure that the Reader is fully loaded and Port was set before any of the requests are executed against reader or before reader itself wants to send some messages to Android side.