### PR TITLE
Add cache versioning for Read Aloud audio

### DIFF
--- a/src/common/read-aloud/remote/index.ts
+++ b/src/common/read-aloud/remote/index.ts
@@ -10,7 +10,7 @@ export type RemoteVoiceConfig = {
 	creditsPerMinute: number;
 	segmentGranularity: ReadAloudGranularity;
 	sentenceDelay?: number;
-	cacheVersion?: number;
+	cacheVersion: number;
 };
 
 export type TierCredits = {
@@ -29,7 +29,7 @@ type VoicesResponseTier = {
 	creditsPerMinute: number;
 	segmentGranularity: ReadAloudGranularity;
 	sentenceDelay?: number;
-	cacheVersion?: number;
+	cacheVersion: number;
 	voices: Record<string, { label: string }>;
 	locales: Record<string, VoicesResponseLocaleConfig | string[]>;
 };

--- a/src/common/read-aloud/remote/index.ts
+++ b/src/common/read-aloud/remote/index.ts
@@ -10,6 +10,7 @@ export type RemoteVoiceConfig = {
 	creditsPerMinute: number;
 	segmentGranularity: ReadAloudGranularity;
 	sentenceDelay?: number;
+	cacheVersion?: number;
 };
 
 export type TierCredits = {
@@ -28,6 +29,7 @@ type VoicesResponseTier = {
 	creditsPerMinute: number;
 	segmentGranularity: ReadAloudGranularity;
 	sentenceDelay?: number;
+	cacheVersion?: number;
 	voices: Record<string, { label: string }>;
 	locales: Record<string, VoicesResponseLocaleConfig | string[]>;
 };
@@ -44,6 +46,7 @@ export type RemoteInterface = {
 	getAudio(segment: ReadAloudSegment | 'sample', voice: RemoteVoiceConfig): Promise<{
 		audio: Blob | null;
 		error?: ErrorState;
+		noStore?: boolean;
 	}>;
 
 	resetCredits(): Promise<TierCredits>;

--- a/src/common/read-aloud/remote/provider.ts
+++ b/src/common/read-aloud/remote/provider.ts
@@ -75,6 +75,7 @@ function parseVoicesResponse(response: VoicesResponse): RemoteVoiceConfig[] {
 						creditsPerMinute: config.creditsPerMinute,
 						segmentGranularity: config.segmentGranularity,
 						sentenceDelay: config.sentenceDelay,
+						cacheVersion: config.cacheVersion,
 					});
 				}
 			}

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -12,38 +12,6 @@ const ZOTERO_API_KEY = process.env.ZOTERO_API_KEY;
 
 window.dev = true;
 
-// Whether the Read Aloud audio cache has been pruned of stale versions this session
-let readAloudCachePruned = false;
-
-// Delete cached audio whose cacheVersion is no longer offered by the server
-async function pruneReadAloudCache(voices) {
-	readAloudCachePruned = true;
-	try {
-		let validVersions = new Set();
-		for (let configs of Object.values(voices)) {
-			if (!Array.isArray(configs)) continue;
-			for (let config of configs) {
-				if (config.cacheVersion !== undefined && config.cacheVersion !== null) {
-					validVersions.add(String(config.cacheVersion));
-				}
-			}
-		}
-		if (!validVersions.size) {
-			return;
-		}
-		let cache = await caches.open('zotero-read-aloud');
-		for (let request of await cache.keys()) {
-			let version = new URL(request.url).searchParams.get('cacheVersion');
-			if (!validVersions.has(version)) {
-				await cache.delete(request);
-			}
-		}
-	}
-	catch (e) {
-		console.error(e);
-	}
-}
-
 async function createReader() {
 	if (window._reader) {
 		throw new Error('Reader is already initialized');
@@ -199,12 +167,8 @@ async function createReader() {
 					? parseInt(response.headers.get('Zotero-TTS-Premium-Credits-Remaining'))
 					: null;
 				let devMode = response.headers.get('Zotero-TTS-Dev') === '1';
-				let voices = await response.json();
-				if (!readAloudCachePruned) {
-					pruneReadAloudCache(voices);
-				}
 				return {
-					voices,
+					voices: await response.json(),
 					standardCreditsRemaining,
 					premiumCreditsRemaining,
 					devMode,

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -12,6 +12,38 @@ const ZOTERO_API_KEY = process.env.ZOTERO_API_KEY;
 
 window.dev = true;
 
+// Whether the Read Aloud audio cache has been pruned of stale versions this session
+let readAloudCachePruned = false;
+
+// Delete cached audio whose cacheVersion is no longer offered by the server
+async function pruneReadAloudCache(voices) {
+	readAloudCachePruned = true;
+	try {
+		let validVersions = new Set();
+		for (let configs of Object.values(voices)) {
+			if (!Array.isArray(configs)) continue;
+			for (let config of configs) {
+				if (config.cacheVersion !== undefined && config.cacheVersion !== null) {
+					validVersions.add(String(config.cacheVersion));
+				}
+			}
+		}
+		if (!validVersions.size) {
+			return;
+		}
+		let cache = await caches.open('zotero-read-aloud');
+		for (let request of await cache.keys()) {
+			let version = new URL(request.url).searchParams.get('cacheVersion');
+			if (!validVersions.has(version)) {
+				await cache.delete(request);
+			}
+		}
+	}
+	catch (e) {
+		console.error(e);
+	}
+}
+
 async function createReader() {
 	if (window._reader) {
 		throw new Error('Reader is already initialized');
@@ -167,8 +199,12 @@ async function createReader() {
 					? parseInt(response.headers.get('Zotero-TTS-Premium-Credits-Remaining'))
 					: null;
 				let devMode = response.headers.get('Zotero-TTS-Dev') === '1';
+				let voices = await response.json();
+				if (!readAloudCachePruned) {
+					pruneReadAloudCache(voices);
+				}
 				return {
-					voices: await response.json(),
+					voices,
 					standardCreditsRemaining,
 					premiumCreditsRemaining,
 					devMode,
@@ -229,8 +265,12 @@ async function createReader() {
 			},
 
 			async getAudio(segment, voice) {
+				let cacheParams = { voice: voice.id, text: segment.text };
+				if (voice.cacheVersion !== undefined && voice.cacheVersion !== null) {
+					cacheParams.cacheVersion = voice.cacheVersion;
+				}
 				let cacheURL = 'https://read-aloud.zotero.invalid/audio?'
-					+ new URLSearchParams({ voice: voice.id, text: segment.text });
+					+ new URLSearchParams(cacheParams);
 				let cache;
 				try {
 					cache = await caches.open('zotero-read-aloud');
@@ -294,14 +334,17 @@ async function createReader() {
 					};
 				}
 
+				let noStore = /(?:^|,)\s*no-store\s*(?:,|$)/i.test(response.headers.get('Cache-Control') || '');
 				let audio = await response.blob();
-				try {
-					await cache?.put(cacheURL, new Response(audio));
+				if (!noStore) {
+					try {
+						await cache?.put(cacheURL, new Response(audio));
+					}
+					catch (e) {
+						console.error(e);
+					}
 				}
-				catch (e) {
-					console.error(e);
-				}
-				return { audio };
+				return { audio, noStore };
 			},
 		},
 		onLogIn() {

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -229,10 +229,7 @@ async function createReader() {
 			},
 
 			async getAudio(segment, voice) {
-				let cacheParams = { voice: voice.id, text: segment.text };
-				if (voice.cacheVersion !== undefined && voice.cacheVersion !== null) {
-					cacheParams.cacheVersion = voice.cacheVersion;
-				}
+				let cacheParams = { voice: voice.id, text: segment.text, cacheVersion: voice.cacheVersion };
 				let cacheURL = 'https://read-aloud.zotero.invalid/audio?'
 					+ new URLSearchParams(cacheParams);
 				let cache;


### PR DESCRIPTION
Propagates the server's per-provider-group `cacheVersion` (from `/tts/voices`) into each flattened voice config so the client can version its local audio cache keys, and surfaces `Cache-Control: no-store` so the client can skip caching those responses.

- `RemoteVoiceConfig` / `VoicesResponseTier`: add `cacheVersion`; `getAudio` return adds `noStore`
- `parseVoicesResponse()`: copy each tier config's `cacheVersion` onto every voice
- Dev reference interface: version cache keys, honor `no-store`, prune stale entries once per session

The actual cache-key/pruning/no-store enforcement lives client-side.

Needed by: zotero/zotero#5967
