### PR TITLE
Discard rendered pages while the reader is in a hidden tab

### DIFF
--- a/src/common/reader.js
+++ b/src/common/reader.js
@@ -2167,6 +2167,14 @@ class Reader {
 		this._updateState({ freeze: false });
 	}
 
+	// Release rendered pages and pause rendering while the reader is in a
+	// hidden (background) tab, and restore them when the tab is shown again.
+	// Currently only has an effect for the PDF view
+	setSuspended(suspended) {
+		this._primaryView?.setSuspended?.(suspended);
+		this._secondaryView?.setSuspended?.(suspended);
+	}
+
 	print() {
 		if (this._type === 'pdf') {
 			if (this._state.annotations.length) {

--- a/src/pdf/page.js
+++ b/src/pdf/page.js
@@ -57,6 +57,11 @@ export default class Page {
 		this._pageRenderer.render();
 	}
 
+	destroy() {
+		this._pageRenderer.destroy();
+		this._detailRenderer.destroy();
+	}
+
 	renderAnnotationOnCanvas(annotation, canvas) {
 		return this._pageRenderer.renderAnnotationOnCanvas(annotation, canvas);
 	}
@@ -93,6 +98,16 @@ class Renderer {
 		return this._isDetailView
 			? this._originalPage.detailView?.canvas
 			: this._originalPage.canvas;
+	}
+
+	// Zero the snapshot canvas to release its backing store immediately,
+	// rather than waiting for GC
+	destroy() {
+		this._snapshotCanvas.width = 0;
+		this._snapshotCanvas.height = 0;
+		this._lastSourceCanvas = null;
+		this._lastSourceSize = { w: 0, h: 0 };
+		this._context = null;
 	}
 
 	_initContext() {

--- a/src/pdf/pdf-view.js
+++ b/src/pdf/pdf-view.js
@@ -682,6 +682,11 @@ class PDFView {
 
 	_handlePageDestroy(originalPage) {
 		let pageIndex = originalPage.id - 1;
+		for (let page of this._pages) {
+			if (page.originalPage === originalPage) {
+				page.destroy();
+			}
+		}
 		this._pages = this._pages.filter(x => x.originalPage !== originalPage);
 		delete this._pdfPages[pageIndex];
 	}
@@ -839,6 +844,36 @@ class PDFView {
 
 	destroy() {
 		this._overlayPopupDelayer.destroy();
+	}
+
+	// Discard rendered pages while the view is hidden (i.e. in a background tab)
+	// to release page canvases, page snapshot canvases and worker-side page
+	// resources, which otherwise are retained for up to 10 pages per view.
+	// Page views stay in place and visible pages re-render on resume
+	setSuspended(suspended) {
+		suspended = !!suspended;
+		if (this._suspended === suspended) {
+			return;
+		}
+		this._suspended = suspended;
+		let app = this._iframeWindow?.PDFViewerApplication;
+		if (!app?.pdfViewer) {
+			return;
+		}
+		if (suspended) {
+			// Prevent new rendering from starting while hidden, otherwise a resize
+			// or scale change would immediately re-render the discarded pages
+			app.pdfRenderingQueue.paused = true;
+			for (let pageView of app.pdfViewer._pages) {
+				pageView.destroy();
+			}
+			// Release worker-side resources (fonts, images) until re-rendering
+			app.pdfDocument?.cleanup().catch(() => {});
+		}
+		else {
+			app.pdfRenderingQueue.paused = false;
+			app.pdfViewer.update();
+		}
 	}
 
 	focus() {


### PR DESCRIPTION
Adds `Reader.setSuspended(suspended)` so the client (Zotero) can release rendered-page memory while a reader tab is hidden and restore it when the tab is shown again. Companion to zotero/pdf.js#6, wired up on the Zotero side by zotero/zotero#5991 (which carries the full root-cause analysis). The set addresses zotero/zotero#5676 and zotero/zotero#3843.

## Why

Each loaded PDF view retains at least 10 fully rendered page canvases (`PDFPageViewBuffer`, `DEFAULT_CACHE_SIZE = 10` — the buffer never shrinks below that). On a 2x HiDPI display at page-width zoom a page canvas is ~2400×3100 device pixels ≈ 30 MB RGBA, up to the `maxCanvasPixels = 2^25` cap. On top of that, the annotation overlay renderer (`src/pdf/page.js`) keeps a full-size `_snapshotCanvas` copy of every rendered page canvas (captured unconditionally in `_maybeRefreshSnapshot()`, even for pages with no annotations), plus extracted per-page data in `_pdfPages`. That's roughly 600 MB per loaded PDF tab, retained indefinitely while the tab is hidden, since nothing is released on tab deselection.

## What this does

- `PDFView.setSuspended(true)`: pauses the rendering queue (needs zotero/pdf.js#6), then destroys all page views through the existing buffer-eviction path — `PDFPageView.destroy()` frees the page canvas and detail-view canvas, releases worker-side page resources, and via the existing `onDestroyPage` hook drops the Zotero `Page` wrapper, its snapshot canvas, and the `_pdfPages` entry. Finally calls `pdfDocument.cleanup()` to release worker-side fonts/images.
- `PDFView.setSuspended(false)`: unpauses the queue and calls `pdfViewer.update()`, so visible pages re-render through the normal path.
- `Reader.setSuspended()` forwards to both split-view panes; EPUB/snapshot views are unaffected (optional-chained no-op).
- `Page`/`Renderer` now get a `destroy()` that zeroes the snapshot canvas backing store on page destroy instead of waiting for GC — this also helps normal scrolling eviction, independent of suspension.

## Testing

`npm run build:zotero` builds cleanly and the queue-pause gate is present in the built `viewer.mjs`. Not yet runtime-tested inside a full Zotero build — happy to iterate if you'd like changes to the approach.
