### PR TITLE
Fix: prevent annotation freeze when editing comments in sidebar

### DIFF
--- a/src/common/focus-manager.js
+++ b/src/common/focus-manager.js
@@ -70,7 +70,7 @@ export class FocusManager {
 
 	_handleFocus(event) {
 		if ('closest' in event.target) {
-			if (!event.target.closest('.annotation, .annotation-popup, .selection-popup, .label-popup, .appearance-popup, .context-menu, iframe')) {
+			if (!event.target.closest('.annotation, .annotation-popup, .selection-popup, .label-popup, .appearance-popup, .context-menu, iframe, [contenteditable="true"]')) {
 				this._onDeselectAnnotations();
 			}
 			// Close find popup on blur if search query is empty


### PR DESCRIPTION
## Problem

When editing annotation comments in the PDF reader sidebar, Zotero freezes completely. This has been reported by multiple users on macOS and Windows:

- https://forums.zotero.org/discussion/129829/trouble-since-update-zotero-8
- Freezes occur when selecting highlighted text and clicking on the comment in the sidebar
- (The freeze seems to occur more often on long comments)
- Once frozen, Zotero becomes completely unresponsive and must be force-quit

