### PR TITLE
Mobile PDF: setScrollMode support

### DIFF
--- a/src/common/view.js
+++ b/src/common/view.js
@@ -362,6 +362,14 @@ class View {
 	}
 
 	/**
+	 * @param {number} mode 0 - vertical, 1 - horizontal, 2 - wrapped
+	 */
+	setScrollMode(mode) {
+		this._ensureType('pdf');
+		this._view.setScrollMode(mode);
+	}
+
+	/**
 	 * @param {string} themeID
 	 */
 	setTheme(themeID) {


### PR DESCRIPTION
It seems that for mobile to support scrollMode changes setScrollMode function needs to be implemented in common/view.js.
Here is the relevant part of PR on Android side:
https://github.com/zotero/zotero-android/pull/333/changes#diff-51784eac957243f11d72191fd5a65b358d9818f33c351cea1e642699b7ea6272R518

