### PR TITLE
PDF Mobile: Stop reader from centering selected annotation

### DIFF
--- a/src/index.android.js
+++ b/src/index.android.js
@@ -176,7 +176,9 @@ window.search = (options) => {
 window.select = (options) => {
 	log("Select: " + options.key);
 	window._view.selectAnnotations([options.key]);
-	window._view.navigate({ annotationID: options.key });
+	if (options.centerInDocument !== false) {
+		window._view.navigate({ annotationID: options.key });
+	}
 };
 
 window.navigate = (options) => {


### PR DESCRIPTION
A part of the fix for https://github.com/zotero/zotero-android/issues/337
Related Pull request on Android side:
https://github.com/zotero/zotero-android/pull/338/changes