### PR TITLE
fix(read-aloud): don't block forever waiting for `voiceschanged`

### DIFF
--- a/src/common/read-aloud/browser/provider.ts
+++ b/src/common/read-aloud/browser/provider.ts
@@ -1,6 +1,8 @@
 import { ReadAloudProvider } from '../provider';
 import { BrowserReadAloudVoice } from './voice';
 
+const VOICES_CHANGED_TIMEOUT = 3000;
+
 export class BrowserReadAloudProvider implements ReadAloudProvider {
 	readonly standardCreditsRemaining = null;
 
@@ -8,8 +10,15 @@ export class BrowserReadAloudProvider implements ReadAloudProvider {
 
 	async getVoices(): Promise<BrowserReadAloudVoice[]> {
 		if (!window.speechSynthesis.getVoices().length) {
-			await new Promise((resolve) => {
-				window.speechSynthesis.addEventListener('voiceschanged', resolve, { once: true });
+			await new Promise<void>((resolve) => {
+				let timeout: ReturnType<typeof setTimeout>;
+				let done = () => {
+					clearTimeout(timeout);
+					window.speechSynthesis.removeEventListener('voiceschanged', done);
+					resolve();
+				};
+				timeout = setTimeout(done, VOICES_CHANGED_TIMEOUT);
+				window.speechSynthesis.addEventListener('voiceschanged', done, { once: true });
 			});
 		}
 		let voices = window.speechSynthesis.getVoices();


### PR DESCRIPTION
`BrowserReadAloudProvider.getVoices()` waits for `voiceschanged` with no timeout
when `speechSynthesis.getVoices()` is empty. On Linux without speech-dispatcher
installed there is no synthesis backend, so the list stays empty, the event
never fires, and the promise never settles.

`ReadAloud.loadVoices()` awaits it in a `Promise.all` alongside the remote
provider, so the entire voice load hangs and the play button spins forever with
no error — Standard and Premium voices included, even with credits available.
The existing `.catch(handleError)` doesn't cover this, since the promise doesn't
reject.

This bounds the wait, so a platform with no local voices resolves to zero local
voices instead of hanging. Where a backend does exist the behavior is unchanged:
a warm registry never reaches the wait, and a cold one fires `voiceschanged`
well inside the timeout.

Fixes zotero/zotero#6040
