### PR TITLE
Added read aloud selection getter

### DIFF
--- a/src/common/view.js
+++ b/src/common/view.js
@@ -6,6 +6,7 @@ import AnnotationManager from './annotation-manager';
 import { DEBOUNCE_STATE_CHANGE, DEBOUNCE_STATS_CHANGE, DEFAULT_THEMES } from './defines';
 import { getCurrentColorScheme } from './lib/utilities';
 import { SDTDocumentSession } from './sdt/document-session.mjs';
+import { isSDTPosition } from './types';
 import { getTextNodeSpans } from './sdt/position-mapper';
 import { buildSDTReadAloudSegments, getSDTLang } from './read-aloud/sdt-segments';
 
@@ -466,6 +467,23 @@ class View {
 	async sdtAnchorToPosition(sdtAnchor) {
 		let sdt = await this._loadSDT();
 		return sdt ? sdt.mapper.sdtToSourcePosition(sdtAnchor) : null;
+	}
+
+	/**
+	 * Structured-document-text position for a source position (an EPUB CFI `FragmentSelector`, a snapshot `CssSelector`),
+	 * or null when it can't be mapped. Positions that are already SDT positions (Reading mode) pass through. The inverse
+	 * of `sdtAnchorToPosition`; requires `setSDTPack` to have been called.
+	 * @returns {Promise<SDTPosition | null>}
+	 */
+	async sourceToSDTPosition(position) {
+		if (!position) {
+			return null;
+		}
+		if (isSDTPosition(position)) {
+			return position;
+		}
+		let sdt = await this._loadSDT();
+		return sdt ? sdt.mapper.sourceToSDTPosition(position) : null;
 	}
 
 	/**

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -171,6 +171,22 @@ window.getReadAloudStartBlockIndex = async (options) => {
 	postMessage('onReadAloudStartBlockIndex', { requestID: options.requestID, blockIndex });
 };
 
+// Maps a source position (the selector the app got for a text selection) to an SDT position, so Read Aloud can start at
+// the selected sentence. Requires the SDT pack, so it's called once the app has handed it over.
+window.sourceToSDTPosition = async (options) => {
+	const source = JSON.parse(decodeBase64(options.position));
+	let position = null;
+	try {
+		position = await window._view.sourceToSDTPosition(source);
+	}
+	catch (error) {
+		log("SDT position for source position unavailable: " + error);
+	}
+	postMessage('onSourceSDTPosition', { requestID: options.requestID, position });
+};
+
+
+
 // Creates the Read Aloud highlight session annotation, or resizes/restyles it when `params.id` is provided. The app
 // keeps the session state (including the annotation id) and stores the annotation only when the session ends, so the
 // resulting annotation is reported back to it.


### PR DESCRIPTION
I need to be able to get a SDT position of current text selection in reader so that the user can long press on text and start Read Aloud from given selection. Claude came up with this and it seems to work fine from my tests.